### PR TITLE
chore: rename all automcp references to gen-mcp/genmcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AutoMCP: Zero-Code MCP Server Generation
+# gen-mcp: Zero-Code MCP Server Generation
 
 > Transform any API into an MCP server in seconds, not hours
 
@@ -8,14 +8,14 @@
 
 **⚠️ Early Preview**: This is a research project in active development. APIs and features may change.
 
-AutoMCP eliminates the complexity of building Model Context Protocol (MCP) servers. Instead of writing boilerplate code and learning protocol internals, simply describe your tools in a configuration file—AutoMCP handles the rest.
+gen-mcp eliminates the complexity of building Model Context Protocol (MCP) servers. Instead of writing boilerplate code and learning protocol internals, simply describe your tools in a configuration file—gen-mcp handles the rest.
 
 **Perfect for:**
 - 🔌 **API Developers** - Expose existing REST APIs to AI assistants instantly
 - 🤖 **AI Engineers** - Connect LLMs to external tools without custom server code  
 - 🛠️ **DevOps Teams** - Integrate legacy systems with modern AI workflows
 
-![AutoMCP System Diagram](./docs/automcp-system-diagram.jpg)
+![gen-mcp System Diagram](./docs/automcp-system-diagram.jpg)
 
 ## ✨ Key Features
 
@@ -32,29 +32,29 @@ AutoMCP eliminates the complexity of building Model Context Protocol (MCP) serve
 
 ```bash
 # Clone and build
-git clone https://github.com/Cali0707/AutoMCP.git
-cd AutoMCP
+git clone https://github.com/genmcp/gen-mcp.git
+cd gen-mcp
 
 # Build CLI and server
-go build -o automcp ./cmd/automcp
-go build -o automcp-server ./cmd/automcp-server
+go build -o genmcp ./cmd/genmcp
+go build -o genmcp-server ./cmd/genmcp-server
 
 # Add to PATH (recommended)
-sudo mv automcp automcp-server /usr/local/bin
+sudo mv genmcp genmcp-server /usr/local/bin
 ```
 
 ### 2. Choose Your Own Adventure
 
 **Option A: Convert Existing API**
 ```bash
-automcp convert https://api.example.com/openapi.json
-automcp run
+genmcp convert https://api.example.com/openapi.json
+genmcp run
 ```
 
 **Option B: Create Custom Tools**
 ```bash
 # Create mcpfile.yaml with your tools (see documentation)
-automcp run
+genmcp run
 ```
 
 ### 3. See It In Action
@@ -72,44 +72,44 @@ automcp run
 
 | Command | Description | Example |
 |---------|-------------|---------|
-| `run` | Start MCP server | `automcp run -f myapi.yaml` |
-| `stop` | Stop running server | `automcp stop` |
-| `convert` | OpenAPI → MCP conversion | `automcp convert api-spec.json` |
+| `run` | Start MCP server | `genmcp run -f myapi.yaml` |
+| `stop` | Stop running server | `genmcp stop` |
+| `convert` | OpenAPI → MCP conversion | `genmcp convert api-spec.json` |
 
 ### Starting Your Server
 
 ```bash
 # Run in foreground (development)
-automcp run -f /path/to/mcpfile.yaml
+genmcp run -f /path/to/mcpfile.yaml
 
 # Run in background
-automcp run -d
+genmcp run -d
 
 # Auto-detect mcpfile.yaml in current directory
-automcp run
+genmcp run
 ```
 
 ### Converting Existing APIs
 
 ```bash
 # From local OpenAPI file
-automcp convert ./api-spec.json
+genmcp convert ./api-spec.json
 
 # From remote OpenAPI URL
-automcp convert https://api.example.com/openapi.json -o custom-name.yaml
+genmcp convert https://api.example.com/openapi.json -o custom-name.yaml
 
 # Petstore example
-automcp convert https://petstore.swagger.io/v2/swagger.json
+genmcp convert https://petstore.swagger.io/v2/swagger.json
 ```
 
 ### Managing Running Servers
 
 ```bash
 # Stop server (uses mcpfile.yaml to find process)
-automcp stop
+genmcp stop
 
 # Stop specific server
-automcp stop -f /path/to/mcpfile.yaml
+genmcp stop -f /path/to/mcpfile.yaml
 ```
 
 ## 📚 Examples & Tutorials
@@ -117,7 +117,7 @@ automcp stop -f /path/to/mcpfile.yaml
 ### 🤖 Ollama Integration
 **[📹 Watch Demo](https://youtu.be/yqJV9rNwfg8)** | **[View Code](./examples/ollama/)**
 
-Connect local language models to MCP Clients with AutoMCP in two ways: by wrapping the Ollama CLI, and by wrapping the Ollama http endpoints.
+Connect local language models to MCP Clients with gen-mcp in two ways: by wrapping the Ollama CLI, and by wrapping the Ollama http endpoints.
 
 **Features:**
 - ✅ HTTP REST API integration
@@ -131,10 +131,10 @@ Transform any REST API into MCP tools automatically:
 
 ```bash
 # 1. Convert OpenAPI spec
-automcp convert http://localhost:9090/openapi.json
+genmcp convert http://localhost:9090/openapi.json
 
 # 2. Run the generated MCP server
-automcp run
+genmcp run
 ```
 
 **Demonstrates:**
@@ -151,8 +151,8 @@ We welcome contributions! This is an early-stage research project with lots of r
 
 ### Development Setup
 ```bash
-git clone https://github.com/your-org/AutoMCP.git
-cd AutoMCP
+git clone https://github.com/genmcp/gen-mcp.git
+cd gen-mcp
 go mod download
 go test ./...
 ```
@@ -164,7 +164,7 @@ Apache 2.0 License - see [LICENSE](LICENSE) file for details.
 ## 🔗 Links
 
 - **[Model Context Protocol](https://modelcontextprotocol.io/)** - Official MCP documentation
-- **[MCP File Format](./docs/mcp_file_format.md)** - AutoMCP configuration reference
+- **[MCP File Format](./docs/mcp_file_format.md)** - gen-mcp configuration reference
 - **[Examples](./examples/)** - Real-world integration examples
 
 ---

--- a/cmd/genmcp-server/main.go
+++ b/cmd/genmcp-server/main.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"sync"
 
-	"github.com/Cali0707/AutoMCP/pkg/mcpfile"
-	"github.com/Cali0707/AutoMCP/pkg/mcpserver"
+	"github.com/genmcp/gen-mcp/pkg/mcpfile"
+	"github.com/genmcp/gen-mcp/pkg/mcpserver"
 )
 
 func main() {

--- a/cmd/genmcp/main.go
+++ b/cmd/genmcp/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/Cali0707/AutoMCP/pkg/cli"
+	"github.com/genmcp/gen-mcp/pkg/cli"
 )
 
 func main() {

--- a/examples/http-conversion/OPENSHIFT_README.md
+++ b/examples/http-conversion/OPENSHIFT_README.md
@@ -2,7 +2,7 @@
 
 📹 **[Watch the demo video](https://youtu.be/boMyFzpgJoA)** to see this example in action!
 
-This example demonstrates AutoMCP's ability to automatically convert HTTP REST API endpoints into MCP tools. AutoMCP can expose any REST API as MCP tools that can be called by AI assistants, eliminating the need to write custom MCP server code.
+This example demonstrates gen-mcp's ability to automatically convert HTTP REST API endpoints into MCP tools. gen-mcp can expose any REST API as MCP tools that can be called by AI assistants, eliminating the need to write custom MCP server code.
 
 ## Getting Started
 
@@ -27,10 +27,10 @@ The API will be available at the url associated with your route with endpoints:
 
 ### 2. Generate Initial MCP Configuration
 
-Use AutoMCP to automatically generate a starter configuration from the API:
+Use gen-mcp to automatically generate a starter configuration from the API:
 
 ```bash
-automcp convert <base route url>/openapi.json -H <base route url>
+genmcp convert <base route url>/openapi.json -H <base route url>
 ```
 
 Note: we are using the `-H` flag here to set the base host url for the api spec, as the openapi.json file says that the endpoints are available at `localhost:9090`.
@@ -56,20 +56,20 @@ Example customizations in this demo:
 First, we need to create a configmap to contain the mcpfile.yaml:
 
 ```bash
-kubectl create cm automcp-config --from-file=mcpfile.yaml
+kubectl create cm genmcp-config --from-file=mcpfile.yaml
 ```
 
-Next, we deploy the AutoMCP server:
+Next, we deploy the gen-mcp server:
 
 ```bash
 cd openshift
 kubectl apply -f config/deployment.yaml -f config/service.yaml -f config/route.yaml
 ```
 
-The MCP service will now be exposed through the `automcp-demo` route, at path `/mcp`. To connect to the server, you will need to use the `streamablehttp` protocol
-and the url `<automcp demo route url>/mcp`.
+The MCP service will now be exposed through the `genmcp-demo` route, at path `/mcp`. To connect to the server, you will need to use the `streamablehttp` protocol
+and the url `<genmcp demo route url>/mcp`.
 
-## Key AutoMCP HTTP Conversion Features
+## Key gen-mcp HTTP Conversion Features
 
 - **Automatic Tool Generation**: HTTP endpoints become MCP tools automatically from OpenAPI specs
 - **Path Parameter Substitution**: URL templates like `{id}` are handled automatically  

--- a/examples/http-conversion/README.md
+++ b/examples/http-conversion/README.md
@@ -2,7 +2,7 @@
 
 📹 **[Watch the demo video](https://youtu.be/boMyFzpgJoA)** to see this example in action!
 
-This example demonstrates AutoMCP's ability to automatically convert HTTP REST API endpoints into MCP tools. AutoMCP can expose any REST API as MCP tools that can be called by AI assistants, eliminating the need to write custom MCP server code.
+This example demonstrates gen-mcp's ability to automatically convert HTTP REST API endpoints into MCP tools. gen-mcp can expose any REST API as MCP tools that can be called by AI assistants, eliminating the need to write custom MCP server code.
 
 ## Getting Started
 
@@ -27,10 +27,10 @@ The API will be available at `http://localhost:9090` with endpoints:
 
 ### 2. Generate Initial MCP Configuration
 
-Use AutoMCP to automatically generate a starter configuration from the API:
+Use gen-mcp to automatically generate a starter configuration from the API:
 
 ```bash
-automcp convert http://localhost:9090/openapi.json
+genmcp convert http://localhost:9090/openapi.json
 ```
 
 This creates an initial `mcpfile.yaml` based on the OpenAPI specification.
@@ -51,15 +51,15 @@ Example customizations in this demo:
 
 ### 4. Start the MCP Server
 
-Launch the AutoMCP server:
+Launch the gen-mcp server:
 
 ```bash
-automcp run mcpfile.yaml
+genmcp run mcpfile.yaml
 ```
 
 The MCP server will run on port 7007 (as configured) and expose the HTTP endpoints as MCP tools that AI assistants can call seamlessly.
 
-## Key AutoMCP HTTP Conversion Features
+## Key gen-mcp HTTP Conversion Features
 
 - **Automatic Tool Generation**: HTTP endpoints become MCP tools automatically from OpenAPI specs
 - **Path Parameter Substitution**: URL templates like `{id}` are handled automatically  

--- a/examples/http-conversion/feature-requests/config/deployment.yaml
+++ b/examples/http-conversion/feature-requests/config/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: feature-request-demo
-        image: ko://github.com/Cali0707/AutoMCP/examples/http-conversion/feature-requests
+        image: ko://github.com/genmcp/gen-mcp/examples/http-conversion/feature-requests
         ports:
         - containerPort: 9090
           name: http

--- a/examples/http-conversion/openshift/config/deployment.yaml
+++ b/examples/http-conversion/openshift/config/deployment.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: automcp-demo
+  name: genmcp-demo
   labels:
-    app: automcp-demo
+    app: genmcp-demo
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: automcp-demo
+      app: genmcp-demo
   template:
     metadata:
       labels:
-        app: automcp-demo
+        app: genmcp-demo
     spec:
       containers:
-      - name: automcp-demo
+      - name: genmcp-demo
         image: quay.io/cmurray/automcp/automcp-server-cb047495ee749d79922dead62115006a
         ports:
         - containerPort: 7007
@@ -29,4 +29,4 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: automcp-config
+          name: genmcp-config

--- a/examples/http-conversion/openshift/config/route.yaml
+++ b/examples/http-conversion/openshift/config/route.yaml
@@ -1,13 +1,13 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: automcp-demo
+  name: genmcp-demo
   labels:
-    app: automcp-demo
+    app: genmcp-demo
 spec:
   to:
     kind: Service
-    name: automcp-demo
+    name: genmcp-demo
     weight: 100
   port:
     targetPort: http

--- a/examples/http-conversion/openshift/config/service.yaml
+++ b/examples/http-conversion/openshift/config/service.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: automcp-demo
+  name: genmcp-demo
   labels:
-    app: automcp-demo
+    app: genmcp-demo
 spec:
   selector:
-    app: automcp-demo
+    app: genmcp-demo
   ports:
   - port: 80
     targetPort: 7007

--- a/examples/ollama/README.md
+++ b/examples/ollama/README.md
@@ -1,8 +1,8 @@
-# 🤖 Talk to Ollama with AutoMCP!
+# 🤖 Talk to Ollama with gen-mcp!
 
 📹 **[Watch the demo video](https://youtu.be/yqJV9rNwfg8)** to see this example in action!
 
-This directory demonstrates two different approaches to integrate Ollama with AutoMCP: HTTP-based and CLI-based methods.
+This directory demonstrates two different approaches to integrate Ollama with gen-mcp: HTTP-based and CLI-based methods.
 
 ## Two Integration Methods
 
@@ -24,14 +24,14 @@ Uses Ollama's command-line interface:
 1. **Make sure Ollama is running** locally (usually at `http://localhost:11434`).
 2. Run the HTTP-based integration:
    ```bash
-   automcp run examples/ollama/ollama-http.yaml
+   genmcp run examples/ollama/ollama-http.yaml
    ```
 
 ### CLI Method  
 1. **Ensure Ollama is installed** and available in your PATH.
 2. Run the CLI-based integration:
    ```bash
-   automcp run examples/ollama/ollama-cli.yaml
+   genmcp run examples/ollama/ollama-cli.yaml
    ```
 
 Both methods expose Ollama functionality as MCP tools, allowing AI assistants to interact with your local language models seamlessly!

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Cali0707/AutoMCP
+module github.com/genmcp/gen-mcp
 
 go 1.24.4
 

--- a/pkg/cli/convert.go
+++ b/pkg/cli/convert.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/Cali0707/AutoMCP/pkg/openapi"
+	"github.com/genmcp/gen-mcp/pkg/openapi"
 	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
 )

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -8,8 +8,8 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "automcp",
-	Short: "automcp manages AutoMCP servers, and their configuration",
+	Use:   "genmcp",
+	Short: "genmcp manages gen-mcp servers, and their configuration",
 }
 
 func Execute() {

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -6,8 +6,8 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/Cali0707/AutoMCP/pkg/cli/utils"
-	"github.com/Cali0707/AutoMCP/pkg/mcpfile"
+	"github.com/genmcp/gen-mcp/pkg/cli/utils"
+	"github.com/genmcp/gen-mcp/pkg/mcpfile"
 	"github.com/spf13/cobra"
 )
 
@@ -27,7 +27,7 @@ var runCmd = &cobra.Command{
 }
 
 func executeRunCmd(cobraCmd *cobra.Command, args []string) {
-	cmd := exec.Command("automcp-server")
+	cmd := exec.Command("genmcp-server")
 	mcpFilePath, err := filepath.Abs(mcpFilePath)
 	if err != nil {
 		fmt.Printf("failed to resolve mcp file path: %s\n", err.Error())
@@ -61,21 +61,21 @@ func executeRunCmd(cobraCmd *cobra.Command, args []string) {
 
 		err := cmd.Run()
 		if err != nil {
-			fmt.Printf("automcp-server failed with %s\n", err.Error())
+			fmt.Printf("genmcp-server failed with %s\n", err.Error())
 		}
 		return
 	}
 
 	err = cmd.Start()
 	if err != nil {
-		fmt.Printf("failed to start automcp-server: %s\n", err.Error())
+		fmt.Printf("failed to start genmcp-server: %s\n", err.Error())
 	}
 
 	processManager := utils.GetProcessManager()
 	err = processManager.SaveProcessId(mcpFilePath, cmd.Process.Pid)
 	if err != nil {
-		fmt.Printf("failed to save pid for automcp server, to stop the server you will need to manually kill pid %d: %s\n", cmd.Process.Pid, err.Error())
+		fmt.Printf("failed to save pid for genmcp server, to stop the server you will need to manually kill pid %d: %s\n", cmd.Process.Pid, err.Error())
 	}
 
-	fmt.Printf("successfully started AutoMCP server...\n")
+	fmt.Printf("successfully started gen-mcp server...\n")
 }

--- a/pkg/cli/stop.go
+++ b/pkg/cli/stop.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/Cali0707/AutoMCP/pkg/cli/utils"
+	"github.com/genmcp/gen-mcp/pkg/cli/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -35,7 +35,7 @@ func executeStopCmd(cobraCmd *cobra.Command, args []string) {
 	processManager := utils.GetProcessManager()
 	pid, err := processManager.GetProcessId(mcpFilePath)
 	if err != nil {
-		fmt.Printf("failed to get pid for automcp server\n")
+		fmt.Printf("failed to get pid for genmcp server\n")
 		return
 	}
 
@@ -48,11 +48,11 @@ func executeStopCmd(cobraCmd *cobra.Command, args []string) {
 
 	err = proc.Kill()
 	if err != nil {
-		fmt.Printf("failed to kill automcp process with pid %d: %s\n", pid, err.Error())
+		fmt.Printf("failed to kill genmcp process with pid %d: %s\n", pid, err.Error())
 		return
 	}
 
 	processManager.DeleteProcessId(mcpFilePath)
 
-	fmt.Printf("successfully stopped AutoMCP server...\n")
+	fmt.Printf("successfully stopped gen-mcp server...\n")
 }

--- a/pkg/cli/utils/cache_file.go
+++ b/pkg/cli/utils/cache_file.go
@@ -12,7 +12,7 @@ func GetCacheDir() (string, error) {
 		return "", fmt.Errorf("failed to get user cache dir: %w", err)
 	}
 
-	dir := filepath.Join(base, ".automcp")
+	dir := filepath.Join(base, ".genmcp")
 
 	err = os.MkdirAll(dir, os.ModePerm)
 	if err != nil {

--- a/pkg/cli/utils/process_manager.go
+++ b/pkg/cli/utils/process_manager.go
@@ -50,18 +50,18 @@ func (pm *ProcessManager) GetProcessId(name string) (int, error) {
 
 	bytes, err := os.ReadFile(pm.filePath)
 	if err != nil {
-		return -1, fmt.Errorf("failed to read %s, unable to find pid for automcp instance: %w", pm.filePath, err)
+		return -1, fmt.Errorf("failed to read %s, unable to find pid for genmcp instance: %w", pm.filePath, err)
 	}
 
 	processes := processes{}
 	err = json.Unmarshal(bytes, &processes)
 	if err != nil {
-		return -1, fmt.Errorf("failed to deserialize the contents of %s, unable to find pid for automcp instance: %w", pm.filePath, err)
+		return -1, fmt.Errorf("failed to deserialize the contents of %s, unable to find pid for genmcp instance: %w", pm.filePath, err)
 	}
 
 	pid, ok := processes[name]
 	if !ok {
-		return -1, fmt.Errorf("no matching pid for automcp instance")
+		return -1, fmt.Errorf("no matching pid for genmcp instance")
 	}
 
 	return pid, nil
@@ -73,20 +73,20 @@ func (pm *ProcessManager) SaveProcessId(name string, pid int) error {
 
 	bytes, err := os.ReadFile(pm.filePath)
 	if err != nil {
-		return fmt.Errorf("failed to read %s, unable to save pid for automcp instance: %w", pm.filePath, err)
+		return fmt.Errorf("failed to read %s, unable to save pid for genmcp instance: %w", pm.filePath, err)
 	}
 
 	processes := processes{}
 	err = json.Unmarshal(bytes, &processes)
 	if err != nil {
-		return fmt.Errorf("failed to deserialize the contents of %s, unable to save pid for automcp instance: %w", pm.filePath, err)
+		return fmt.Errorf("failed to deserialize the contents of %s, unable to save pid for genmcp instance: %w", pm.filePath, err)
 	}
 
 	processes[name] = pid
 
 	bytes, err = json.Marshal(processes)
 	if err != nil {
-		return fmt.Errorf("failed to serialize the processes map, unable to save pid for automcp instance: %w", err)
+		return fmt.Errorf("failed to serialize the processes map, unable to save pid for genmcp instance: %w", err)
 	}
 
 	err = os.WriteFile(pm.filePath, bytes, 0644)
@@ -100,20 +100,20 @@ func (pm *ProcessManager) DeleteProcessId(name string) error {
 
 	bytes, err := os.ReadFile(pm.filePath)
 	if err != nil {
-		return fmt.Errorf("failed to read %s, unable to delete pid for automcp instance: %w", pm.filePath, err)
+		return fmt.Errorf("failed to read %s, unable to delete pid for genmcp instance: %w", pm.filePath, err)
 	}
 
 	processes := processes{}
 	err = json.Unmarshal(bytes, &processes)
 	if err != nil {
-		return fmt.Errorf("failed to deserialize the contents of %s, unable to delete pid for automcp instance: %w", pm.filePath, err)
+		return fmt.Errorf("failed to deserialize the contents of %s, unable to delete pid for genmcp instance: %w", pm.filePath, err)
 	}
 
 	delete(processes, name)
 
 	bytes, err = json.Marshal(processes)
 	if err != nil {
-		return fmt.Errorf("failed to serialize the processes map, unable to delete pid for automcp instance: %w", err)
+		return fmt.Errorf("failed to serialize the processes map, unable to delete pid for genmcp instance: %w", err)
 	}
 
 	err = os.WriteFile(pm.filePath, bytes, 0644)

--- a/pkg/mcpserver/server.go
+++ b/pkg/mcpserver/server.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 	mcpserver "github.com/mark3labs/mcp-go/server"
 
-	"github.com/Cali0707/AutoMCP/pkg/mcpfile"
+	"github.com/genmcp/gen-mcp/pkg/mcpfile"
 )
 
 func MakeServer(mcpServer *mcpfile.MCPServer) *mcpserver.MCPServer {

--- a/pkg/openapi/openapi.go
+++ b/pkg/openapi/openapi.go
@@ -9,7 +9,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/Cali0707/AutoMCP/pkg/mcpfile"
+	"github.com/genmcp/gen-mcp/pkg/mcpfile"
 	"github.com/pb33f/libopenapi"
 	highbase "github.com/pb33f/libopenapi/datamodel/high/base"
 	v2high "github.com/pb33f/libopenapi/datamodel/high/v2"
@@ -78,7 +78,7 @@ func McpFileFromOpenApiV2Model(model *v2high.Swagger, host string) (*mcpfile.MCP
 	} else if slices.Contains(model.Schemes, "http") {
 		scheme = "http"
 	} else {
-		return nil, fmt.Errorf("no valid scheme set on swagger document: AutoMCP requires one of (http, https)")
+		return nil, fmt.Errorf("no valid scheme set on swagger document: gen-mcp requires one of (http, https)")
 	}
 
 	urlHost := model.Host

--- a/pkg/openapi/openapi_test.go
+++ b/pkg/openapi/openapi_test.go
@@ -12,8 +12,8 @@ import (
 func TestConvertFromOpenApiSpec(t *testing.T) {
 	docBytes, _ := os.ReadFile("testdata/petstorev3.json")
 
-	mcpfile, err := DocumentToMcpFile(docBytes)
-	assert.Error(t, err, "creating the mcp file from the openapi model should have errors on endpoints automcp does not support")
+	mcpfile, err := DocumentToMcpFile(docBytes, "")
+	assert.Error(t, err, "creating the mcp file from the openapi model should have errors on endpoints genmcp does not support")
 	assert.NotNil(t, mcpfile)
 
 	mcpYaml, err := yaml.Marshal(mcpfile)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Cali0707/AutoMCP/pkg/mcpfile"
-	"github.com/Cali0707/AutoMCP/pkg/mcpserver"
+	"github.com/genmcp/gen-mcp/pkg/mcpfile"
+	"github.com/genmcp/gen-mcp/pkg/mcpserver"
 	mcpclient "github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"


### PR DESCRIPTION
Since we renamed the project in #23 - this updates all the references throughout