### PR TITLE
feat: make server base path configurable

### DIFF
--- a/pkg/mcpfile/parser_test.go
+++ b/pkg/mcpfile/parser_test.go
@@ -32,6 +32,7 @@ func TestParseMcpFile(t *testing.T) {
 							TransportProtocol: TransportProtocolStreamableHttp,
 							StreamableHTTPConfig: &StreamableHTTPConfig{
 								Port: 3000,
+								BasePath: "/mcp",
 							},
 						},
 					},
@@ -50,6 +51,7 @@ func TestParseMcpFile(t *testing.T) {
 							TransportProtocol: TransportProtocolStreamableHttp,
 							StreamableHTTPConfig: &StreamableHTTPConfig{
 								Port: 3000,
+								BasePath: "/mcp",
 							},
 						},
 						Tools: []*Tool{
@@ -89,6 +91,7 @@ func TestParseMcpFile(t *testing.T) {
 							TransportProtocol: TransportProtocolStreamableHttp,
 							StreamableHTTPConfig: &StreamableHTTPConfig{
 								Port: 3000,
+								BasePath: "/mcp",
 							},
 						},
 						Tools: []*Tool{
@@ -129,6 +132,7 @@ func TestParseMcpFile(t *testing.T) {
 							TransportProtocol: TransportProtocolStreamableHttp,
 							StreamableHTTPConfig: &StreamableHTTPConfig{
 								Port: 3000,
+								BasePath: "/mcp",
 							},
 						},
 						Tools: []*Tool{
@@ -240,6 +244,7 @@ func TestParseMcpFile(t *testing.T) {
 							TransportProtocol: "streamablehttp",
 							StreamableHTTPConfig: &StreamableHTTPConfig{
 								Port: 8008,
+								BasePath: "/mcp",
 							},
 						},
 						Tools: []*Tool{

--- a/pkg/mcpfile/types.go
+++ b/pkg/mcpfile/types.go
@@ -66,7 +66,8 @@ type Tool struct {
 }
 
 type StreamableHTTPConfig struct {
-	Port int `json:"port"` // the port to start listening on
+	Port     int    `json:"port"`     // the port to start listening on
+	BasePath string `json:"basePath"` // the base path for the MCP server
 }
 
 type StdioConfig struct {

--- a/pkg/mcpfile/validation.go
+++ b/pkg/mcpfile/validation.go
@@ -177,6 +177,10 @@ func (r *ServerRuntime) Validate() error {
 		if r.StreamableHTTPConfig.Port <= 0 {
 			err = errors.Join(err, fmt.Errorf("streamableHttpConfig.port must be greater than 0"))
 		}
+
+		if r.StreamableHTTPConfig.BasePath == "" {
+			r.StreamableHTTPConfig.BasePath = "/mcp"
+		}
 	}
 
 	return err

--- a/pkg/mcpserver/server.go
+++ b/pkg/mcpserver/server.go
@@ -36,7 +36,7 @@ func RunServer(mcpServer *mcpfile.MCPServer) error {
 
 	switch strings.ToLower(mcpServer.Runtime.TransportProtocol) {
 	case mcpfile.TransportProtocolStreamableHttp:
-		httpServer := server.NewStreamableHTTPServer(s)
+		httpServer := server.NewStreamableHTTPServer(s, server.WithEndpointPath(mcpServer.Runtime.StreamableHTTPConfig.BasePath))
 		fmt.Printf("starting listen on :%d\n", mcpServer.Runtime.StreamableHTTPConfig.Port)
 		if err := httpServer.Start(fmt.Sprintf(":%d", mcpServer.Runtime.StreamableHTTPConfig.Port)); err != nil {
 			return err


### PR DESCRIPTION
Fixes #40 

This PR adds support for configuring the base path for the streamable http protocol, and defaults the path to `/mcp`.

To set the path, users can configure the server like:

```yaml
runtime:
  streamableHttpConfig:
    basePath: /some/path
```