### PR TITLE
Fix `genmcp run` call in examples

### DIFF
--- a/examples/http-conversion/README.md
+++ b/examples/http-conversion/README.md
@@ -54,7 +54,7 @@ Example customizations in this demo:
 Launch the gen-mcp server:
 
 ```bash
-genmcp run mcpfile.yaml
+genmcp run -f mcpfile.yaml
 ```
 
 The MCP server will run on port 7007 (as configured) and expose the HTTP endpoints as MCP tools that AI assistants can call seamlessly.

--- a/examples/ollama/README.md
+++ b/examples/ollama/README.md
@@ -24,14 +24,14 @@ Uses Ollama's command-line interface:
 1. **Make sure Ollama is running** locally (usually at `http://localhost:11434`).
 2. Run the HTTP-based integration:
    ```bash
-   genmcp run examples/ollama/ollama-http.yaml
+   genmcp run -f examples/ollama/ollama-http.yaml
    ```
 
 ### CLI Method  
 1. **Ensure Ollama is installed** and available in your PATH.
 2. Run the CLI-based integration:
    ```bash
-   genmcp run examples/ollama/ollama-cli.yaml
+   genmcp run -f examples/ollama/ollama-cli.yaml
    ```
 
 Both methods expose Ollama functionality as MCP tools, allowing AI assistants to interact with your local language models seamlessly!


### PR DESCRIPTION
Adding the missing `-f` in the genmcp run calls in the examples