### PR TITLE
fix: fix incorrect dependabot date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,7 +36,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-      day: "first-tuesday"
+      day: "tuesday"
       time: "10:00"
       timezone: "UTC"
     open-pull-requests-limit: 3


### PR DESCRIPTION
Github is complaining about our dependabot config with the following error:
`The property '#/updates/1/schedule/day' value "first-tuesday" did not match one of the following values: monday, tuesday, wednesday, thursday, friday, saturday, sunday`

This PR should fix that