### PR TITLE
Switch default server port from 7007 to 8080 to be more consistent with other tools.

### DIFF
--- a/examples/http-conversion/K8S_README.md
+++ b/examples/http-conversion/K8S_README.md
@@ -116,10 +116,10 @@ ko apply -f toolhive/mcp-server.yaml
 Use kubectl port-forward to access the MCP server:
 
 ```bash
-kubectl port-forward services/mcp-genmcp-proxy 7007:7007
+kubectl port-forward services/mcp-genmcp-proxy 8080:8080
 ```
 
-The MCP service will now be accessible at `http://localhost:7007/mcp`. To connect to the server, you will need to use the `streamablehttp` protocol and the url `http://localhost:7007/mcp`.
+The MCP service will now be accessible at `http://localhost:8080/mcp`. To connect to the server, you will need to use the `streamablehttp` protocol and the url `http://localhost:8080/mcp`.
 
 ### 9. Test the MCP Server
 
@@ -130,7 +130,7 @@ You can test the MCP server by connecting with an MCP client or by using tools l
 curl http://localhost:9090/features
 
 # Test the MCP server health (if available)
-curl http://localhost:7007/health
+curl http://localhost:8080/health
 ```
 
 ## Key gen-mcp HTTP Conversion Features

--- a/examples/http-conversion/README.md
+++ b/examples/http-conversion/README.md
@@ -57,12 +57,12 @@ Launch the gen-mcp server:
 genmcp run -f mcpfile.yaml
 ```
 
-The MCP server will run on port 7007 (as configured) and expose the HTTP endpoints as MCP tools that AI assistants can call seamlessly.
+The MCP server will run on port 8080 (as configured) and expose the HTTP endpoints as MCP tools that AI assistants can call seamlessly.
 
 ## Key gen-mcp HTTP Conversion Features
 
 - **Automatic Tool Generation**: HTTP endpoints become MCP tools automatically from OpenAPI specs
-- **Path Parameter Substitution**: URL templates like `{id}` are handled automatically  
+- **Path Parameter Substitution**: URL templates like `{id}` are handled automatically
 - **Schema Validation**: Input parameters are validated before API calls
 - **Streamable HTTP Protocol**: Real-time communication via `streamablehttp`
 - **Flexible Configuration**: Full control over which endpoints to expose and how

--- a/examples/http-conversion/feature-requests/mcpfile.yaml
+++ b/examples/http-conversion/feature-requests/mcpfile.yaml
@@ -3,7 +3,7 @@ servers:
 - name: Feature Request API
   runtime:
     streamableHttpConfig:
-      port: 7007
+      port: 8080
     transportProtocol: streamablehttp
   tools:
   - description: Returns a list of all features sorted by upvotes (highest first)

--- a/examples/http-conversion/mcpfile.yaml
+++ b/examples/http-conversion/mcpfile.yaml
@@ -3,7 +3,7 @@ servers:
 - name: Feature Request API
   runtime:
     streamableHttpConfig:
-      port: 7007
+      port: 8080
     transportProtocol: streamablehttp
   tools:
   - description: Returns a list of all features sorted by upvotes (highest first)

--- a/examples/http-conversion/oauth-mcpfile.yaml
+++ b/examples/http-conversion/oauth-mcpfile.yaml
@@ -3,7 +3,7 @@ servers:
 - name: Feature Request API
   runtime:
     streamableHttpConfig:
-      port: 7007
+      port: 8080
       auth:
         authorizationServers:
           - http://localhost:8080/realms/master

--- a/examples/http-conversion/openshift/config/deployment.yaml
+++ b/examples/http-conversion/openshift/config/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       - name: genmcp-demo
         image: ko://github.com/genmcp/gen-mcp/cmd/genmcp-server
         ports:
-        - containerPort: 7007
+        - containerPort: 8080
           name: http
         env:
         - name: MCP_FILE_PATH

--- a/examples/http-conversion/openshift/config/service.yaml
+++ b/examples/http-conversion/openshift/config/service.yaml
@@ -9,7 +9,7 @@ spec:
     app: genmcp-demo
   ports:
   - port: 80
-    targetPort: 7007
+    targetPort: 8080
     protocol: TCP
     name: http
   type: ClusterIP

--- a/examples/http-conversion/toolhive/mcp-server.yaml
+++ b/examples/http-conversion/toolhive/mcp-server.yaml
@@ -5,8 +5,8 @@ metadata:
 spec:
   image: ko://github.com/genmcp/gen-mcp/cmd/genmcp-server
   transport: streamable-http
-  port: 7007
-  targetPort: 7007
+  port: 8080
+  targetPort: 8080
   permissionProfile:
     type: builtin
     name: network

--- a/pkg/openapi/openapi.go
+++ b/pkg/openapi/openapi.go
@@ -44,7 +44,7 @@ func McpFileFromOpenApiV2Model(model *v2high.Swagger, host string) (*mcpfile.MCP
 		return nil, fmt.Errorf("no host provided in the swagger file, unable to construct valid URLs.")
 	}
 	// 1. Set top level MCP file info
-	// 2. Create a server in the MCP file, default to streamablehttp transport w. port 7007
+	// 2. Create a server in the MCP file, default to streamablehttp transport w. port 8080
 	// 3 for each (path, operation) in the document, add one tool to the server w. http invoke
 	res := &mcpfile.MCPFile{
 		FileVersion: mcpfile.MCPFileVersion,
@@ -54,7 +54,7 @@ func McpFileFromOpenApiV2Model(model *v2high.Swagger, host string) (*mcpfile.MCP
 		Runtime: &mcpfile.ServerRuntime{
 			TransportProtocol: mcpfile.TransportProtocolStreamableHttp,
 			StreamableHTTPConfig: &mcpfile.StreamableHTTPConfig{
-				Port: 7007,
+				Port: 8080,
 			},
 		},
 		Tools:   []*mcpfile.Tool{},
@@ -176,7 +176,7 @@ func McpFileFromOpenApiV2Model(model *v2high.Swagger, host string) (*mcpfile.MCP
 }
 func McpFileFromOpenApiV3Model(model *v3high.Document, host string) (*mcpfile.MCPFile, error) {
 	// 1. Set top level MCP file info
-	// 2. Create a server in the MCP file, default to streamablehttp transport w. port 7007
+	// 2. Create a server in the MCP file, default to streamablehttp transport w. port 8080
 	// 3 for each (path, operation) in the document, add one tool to the server w. http invoke
 	res := &mcpfile.MCPFile{
 		FileVersion: mcpfile.MCPFileVersion,
@@ -186,7 +186,7 @@ func McpFileFromOpenApiV3Model(model *v3high.Document, host string) (*mcpfile.MC
 		Runtime: &mcpfile.ServerRuntime{
 			TransportProtocol: mcpfile.TransportProtocolStreamableHttp,
 			StreamableHTTPConfig: &mcpfile.StreamableHTTPConfig{
-				Port: 7007,
+				Port: 8080,
 			},
 		},
 		Tools:   []*mcpfile.Tool{},

--- a/pkg/openapi/openapi_test.go
+++ b/pkg/openapi/openapi_test.go
@@ -21,3 +21,14 @@ func TestConvertFromOpenApiSpec(t *testing.T) {
 
 	fmt.Printf("%s", mcpYaml)
 }
+
+func TestDefaultPort8080InOpenAPIV3Conversion(t *testing.T) {
+	docBytes, _ := os.ReadFile("testdata/petstorev3.json")
+
+	mcpfile, err := DocumentToMcpFile(docBytes, "")
+	assert.Error(t, err, "creating the mcp file from the openapi model should have errors on endpoints genmcp does not support")
+	assert.NotNil(t, mcpfile)
+
+	server := mcpfile.Servers[0]
+	assert.Equal(t, 8080, server.Runtime.StreamableHTTPConfig.Port, "OpenAPI v3 conversion should default to port 8080")
+}


### PR DESCRIPTION
Fixes: #42 

Changes:
 - Switch default server port from 7007 to 8080 to be more consistent with other tools.
 - Also changed the port in example files

Note:
wanted to get more familiar with the project so picked up a `good-first-issue`