### PR TITLE
add golangci-lint github action

### DIFF
--- a/.github/workflows/pr-golangci-lint.yaml
+++ b/.github/workflows/pr-golangci-lint.yaml
@@ -1,0 +1,31 @@
+name: golangci-lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  FORCE_COLOR: true
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.1

--- a/examples/http-conversion/feature-requests/main.go
+++ b/examples/http-conversion/feature-requests/main.go
@@ -98,7 +98,10 @@ func getTopFeature(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	if topFeature == nil {
 		w.WriteHeader(http.StatusNotFound)
-		json.NewEncoder(w).Encode(map[string]string{"error": "No features found"})
+		if err := json.NewEncoder(w).Encode(map[string]string{"error": "No features found"}); err != nil {
+			http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+			return
+		}
 		return
 	}
 
@@ -108,7 +111,10 @@ func getTopFeature(w http.ResponseWriter, r *http.Request) {
 		Upvotes:   topFeature.Upvotes,
 		Completed: topFeature.Completed,
 	}
-	json.NewEncoder(w).Encode(summary)
+	if err := json.NewEncoder(w).Encode(summary); err != nil {
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+		return
+	}
 }
 
 func addFeature(w http.ResponseWriter, r *http.Request) {
@@ -116,14 +122,20 @@ func addFeature(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid JSON"})
+		if err := json.NewEncoder(w).Encode(map[string]string{"error": "Invalid JSON"}); err != nil {
+			http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+			return
+		}
 		return
 	}
 
 	if req.Title == "" {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(map[string]string{"error": "Title is required"})
+		if err := json.NewEncoder(w).Encode(map[string]string{"error": "Title is required"}); err != nil {
+			http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+			return
+		}
 		return
 	}
 
@@ -142,7 +154,10 @@ func addFeature(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
-	json.NewEncoder(w).Encode(feature)
+	if err := json.NewEncoder(w).Encode(feature); err != nil {
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+		return
+	}
 }
 
 func voteForFeature(w http.ResponseWriter, r *http.Request) {
@@ -150,7 +165,10 @@ func voteForFeature(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid JSON"})
+		if err := json.NewEncoder(w).Encode(map[string]string{"error": "Invalid JSON"}); err != nil {
+			http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+			return
+		}
 		return
 	}
 
@@ -160,7 +178,10 @@ func voteForFeature(w http.ResponseWriter, r *http.Request) {
 		mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
-		json.NewEncoder(w).Encode(map[string]string{"error": "Feature not found"})
+		if err := json.NewEncoder(w).Encode(map[string]string{"error": "Feature not found"}); err != nil {
+			http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+			return
+		}
 		return
 	}
 
@@ -168,7 +189,10 @@ func voteForFeature(w http.ResponseWriter, r *http.Request) {
 	mu.Unlock()
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(feature)
+	if err := json.NewEncoder(w).Encode(feature); err != nil {
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+		return
+	}
 }
 
 func getFeatureDetails(w http.ResponseWriter, r *http.Request) {
@@ -177,7 +201,10 @@ func getFeatureDetails(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid feature ID"})
+		if err := json.NewEncoder(w).Encode(map[string]string{"error": "Invalid feature ID"}); err != nil {
+			http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+			return
+		}
 		return
 	}
 
@@ -188,11 +215,17 @@ func getFeatureDetails(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	if !exists {
 		w.WriteHeader(http.StatusNotFound)
-		json.NewEncoder(w).Encode(map[string]string{"error": "Feature not found"})
+		if err := json.NewEncoder(w).Encode(map[string]string{"error": "Feature not found"}); err != nil {
+			http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+			return
+		}
 		return
 	}
 
-	json.NewEncoder(w).Encode(feature)
+	if err := json.NewEncoder(w).Encode(feature); err != nil {
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+		return
+	}
 }
 
 func getAllFeatures(w http.ResponseWriter, r *http.Request) {
@@ -219,7 +252,10 @@ func getAllFeatures(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(summaries)
+	if err := json.NewEncoder(w).Encode(summaries); err != nil {
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+		return
+	}
 }
 
 func getOpenAPISpec(w http.ResponseWriter, r *http.Request) {
@@ -237,13 +273,23 @@ func getOpenAPISpec(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(map[string]string{"error": "OpenAPI spec not found"})
+		if err := json.NewEncoder(w).Encode(map[string]string{"error": "OpenAPI spec not found"}); err != nil {
+			http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+			return
+		}
 		return
 	}
-	defer file.Close()
+	defer func() {
+		if err := file.Close(); err != nil {
+			http.Error(w, "Failed to close file", http.StatusInternalServerError)
+		}
+	}()
 
 	w.Header().Set("Content-Type", "application/json")
-	io.Copy(w, file)
+	if _, err := io.Copy(w, file); err != nil {
+		http.Error(w, "Failed to copy file content", http.StatusInternalServerError)
+		return
+	}
 }
 
 func deleteFeature(w http.ResponseWriter, r *http.Request) {
@@ -252,7 +298,10 @@ func deleteFeature(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid feature ID"})
+		if err := json.NewEncoder(w).Encode(map[string]string{"error": "Invalid feature ID"}); err != nil {
+			http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+			return
+		}
 		return
 	}
 
@@ -262,7 +311,10 @@ func deleteFeature(w http.ResponseWriter, r *http.Request) {
 		mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
-		json.NewEncoder(w).Encode(map[string]string{"error": "Feature not found"})
+		if err := json.NewEncoder(w).Encode(map[string]string{"error": "Feature not found"}); err != nil {
+			http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+			return
+		}
 		return
 	}
 
@@ -278,7 +330,10 @@ func completeFeature(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid JSON"})
+		if err := json.NewEncoder(w).Encode(map[string]string{"error": "Invalid JSON"}); err != nil {
+			http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+			return
+		}
 		return
 	}
 
@@ -288,7 +343,10 @@ func completeFeature(w http.ResponseWriter, r *http.Request) {
 		mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
-		json.NewEncoder(w).Encode(map[string]string{"error": "Feature not found"})
+		if err := json.NewEncoder(w).Encode(map[string]string{"error": "Feature not found"}); err != nil {
+			http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+			return
+		}
 		return
 	}
 
@@ -296,5 +354,8 @@ func completeFeature(w http.ResponseWriter, r *http.Request) {
 	mu.Unlock()
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(feature)
+	if err := json.NewEncoder(w).Encode(feature); err != nil {
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+		return
+	}
 }

--- a/pkg/cli/stop.go
+++ b/pkg/cli/stop.go
@@ -42,7 +42,9 @@ func executeStopCmd(cobraCmd *cobra.Command, args []string) {
 	proc, err := os.FindProcess(pid)
 	if err != nil {
 		fmt.Printf("failed to find process for pid %d: %s\n", pid, err.Error())
-		processManager.DeleteProcessId(mcpFilePath)
+		if err := processManager.DeleteProcessId(mcpFilePath); err != nil {
+			fmt.Printf("failed to delete process id: %s\n", err.Error())
+		}
 		return
 	}
 
@@ -52,7 +54,9 @@ func executeStopCmd(cobraCmd *cobra.Command, args []string) {
 		return
 	}
 
-	processManager.DeleteProcessId(mcpFilePath)
+	if err := processManager.DeleteProcessId(mcpFilePath); err != nil {
+		fmt.Printf("failed to delete process id: %s\n", err.Error())
+	}
 
 	fmt.Printf("successfully stopped gen-mcp server...\n")
 }

--- a/pkg/cli/utils/process_manager.go
+++ b/pkg/cli/utils/process_manager.go
@@ -24,8 +24,14 @@ func init() {
 		if err != nil {
 			panic(err)
 		}
-		f.WriteString("{}")
-		f.Close()
+		_, err = f.WriteString("{}")
+		if err != nil {
+			panic(err)
+		}
+		err = f.Close()
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	manager = &ProcessManager{
@@ -89,9 +95,7 @@ func (pm *ProcessManager) SaveProcessId(name string, pid int) error {
 		return fmt.Errorf("failed to serialize the processes map, unable to save pid for genmcp instance: %w", err)
 	}
 
-	err = os.WriteFile(pm.filePath, bytes, 0644)
-
-	return nil
+	return os.WriteFile(pm.filePath, bytes, 0644)
 }
 
 func (pm *ProcessManager) DeleteProcessId(name string) error {
@@ -116,7 +120,5 @@ func (pm *ProcessManager) DeleteProcessId(name string) error {
 		return fmt.Errorf("failed to serialize the processes map, unable to delete pid for genmcp instance: %w", err)
 	}
 
-	err = os.WriteFile(pm.filePath, bytes, 0644)
-
-	return nil
+	return os.WriteFile(pm.filePath, bytes, 0644)
 }

--- a/pkg/mcpfile/tools.go
+++ b/pkg/mcpfile/tools.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	neturl "net/url"
 	"os/exec"
@@ -160,7 +161,11 @@ func (h *HttpInvocation) HandleRequest(ctx context.Context, req mcp.CallToolRequ
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("request to tool endpoint failed: %s", err.Error())), nil
 	}
-	defer response.Body.Close()
+	defer func() {
+		if err := response.Body.Close(); err != nil {
+			log.Printf("error closing response body: %v", err)
+		}
+	}()
 
 	body, _ := io.ReadAll(response.Body)
 	return mcp.NewToolResultText(string(body)), nil

--- a/pkg/mcpserver/server.go
+++ b/pkg/mcpserver/server.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 
 	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
 	mcpserver "github.com/mark3labs/mcp-go/server"
 
 	"github.com/genmcp/gen-mcp/pkg/mcpfile"
@@ -22,8 +21,8 @@ func MakeServer(mcpServer *mcpfile.MCPServer) *mcpserver.MCPServer {
 	s := mcpserver.NewMCPServer(
 		mcpServer.Name,
 		mcpServer.Version,
-		server.WithToolCapabilities(true),
-		server.WithToolFilter(filterAuthorizedTools(mcpServer)),
+		mcpserver.WithToolCapabilities(true),
+		mcpserver.WithToolFilter(filterAuthorizedTools(mcpServer)),
 	)
 
 	for _, t := range mcpServer.Tools {
@@ -48,7 +47,7 @@ func RunServer(ctx context.Context, mcpServerConfig *mcpfile.MCPServer) error {
 		mux := http.NewServeMux()
 
 		// Set up MCP server under /mcp (or whatever is under BasePath)
-		mcpServer := server.NewStreamableHTTPServer(s)
+		mcpServer := mcpserver.NewStreamableHTTPServer(s)
 		mux.Handle(mcpServerConfig.Runtime.StreamableHTTPConfig.BasePath, oauth.Middleware(mcpServerConfig)(mcpServer))
 
 		// Set up OAuth protected resource metadata endpoint under / if needed
@@ -81,7 +80,7 @@ func RunServer(ctx context.Context, mcpServerConfig *mcpfile.MCPServer) error {
 			return err
 		}
 	case mcpfile.TransportProtocolStdio:
-		stdioServer := server.NewStdioServer(s)
+		stdioServer := mcpserver.NewStdioServer(s)
 		return stdioServer.Listen(ctx, os.Stdin, os.Stdout)
 	default:
 		return fmt.Errorf("tried running invalid transport protocol")
@@ -149,7 +148,7 @@ func createAuthorizedToolHandler(tool *mcpfile.Tool) func(context.Context, mcp.C
 	}
 }
 
-func filterAuthorizedTools(mcpServerConfig *mcpfile.MCPServer) server.ToolFilterFunc {
+func filterAuthorizedTools(mcpServerConfig *mcpfile.MCPServer) mcpserver.ToolFilterFunc {
 	return func(ctx context.Context, tools []mcp.Tool) []mcp.Tool {
 		var allowedTools []mcp.Tool
 

--- a/pkg/oauth/middleware.go
+++ b/pkg/oauth/middleware.go
@@ -2,6 +2,7 @@ package oauth
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"slices"
 	"strings"
@@ -75,7 +76,10 @@ func write401(w http.ResponseWriter, r *http.Request, body string) {
 	w.Header().Set("WWW-Authenticate", fmt.Sprintf("Bearer resource_metadata=%q", fullWellKnownPath))
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusUnauthorized)
-	w.Write([]byte(body))
+	_, err := w.Write([]byte(body))
+	if err != nil {
+		log.Printf("failed to write response: %v", err)
+	}
 }
 
 func ProtectedResourceMetadataHandler(config *mcpfile.MCPServer) http.HandlerFunc {

--- a/pkg/oauth/tokenvalidator.go
+++ b/pkg/oauth/tokenvalidator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"slices"
 	"strings"
@@ -200,7 +201,11 @@ func (tv *TokenValidator) isValidJWKSEndpoint(ctx context.Context, jwksURL strin
 	if err != nil {
 		return false
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("error closing response body: %v", err)
+		}
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		return false
@@ -222,7 +227,11 @@ func (tv *TokenValidator) discoverFromOIDC(ctx context.Context, discoveryURL str
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("error closing response body: %v", err)
+		}
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("OIDC discovery endpoint returned status %d", resp.StatusCode)

--- a/pkg/openapi/openapi.go
+++ b/pkg/openapi/openapi.go
@@ -41,7 +41,7 @@ func DocumentToMcpFile(document []byte, host string) (*mcpfile.MCPFile, error) {
 
 func McpFileFromOpenApiV2Model(model *v2high.Swagger, host string) (*mcpfile.MCPFile, error) {
 	if model.Host == "" && host == "" {
-		return nil, fmt.Errorf("no host provided in the swagger file, unable to construct valid URLs.")
+		return nil, fmt.Errorf("no host provided in the swagger file, unable to construct valid URLs")
 	}
 	// 1. Set top level MCP file info
 	// 2. Create a server in the MCP file, default to streamablehttp transport w. port 8080

--- a/test/auth_test.go
+++ b/test/auth_test.go
@@ -99,7 +99,10 @@ var _ = Describe("OAuth Integration", Ordered, func() {
 				By("making a request to the metadata endpoint")
 				resp, err := http.Get("http://localhost:8018/.well-known/oauth-protected-resource")
 				Expect(err).NotTo(HaveOccurred())
-				defer resp.Body.Close()
+				defer func() {
+					err := resp.Body.Close()
+					Expect(err).NotTo(HaveOccurred())
+				}()
 
 				By("returning HTTP 200 OK")
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -109,7 +112,10 @@ var _ = Describe("OAuth Integration", Ordered, func() {
 				By("making a request to the metadata endpoint")
 				resp, err := http.Get("http://localhost:8018/.well-known/oauth-protected-resource")
 				Expect(err).NotTo(HaveOccurred())
-				defer resp.Body.Close()
+				defer func() {
+					err := resp.Body.Close()
+					Expect(err).NotTo(HaveOccurred())
+				}()
 
 				By("returning HTTP 200 OK")
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -142,7 +148,10 @@ var _ = Describe("OAuth Integration", Ordered, func() {
 				By("creating OAuth MCP client")
 				tokenStore := mcpclient.NewMemoryTokenStore()
 				client := createOAuthMCPClientWithTokenStore(mcpServerURL, clientID, tokenStore)
-				defer client.Close()
+				defer func() {
+					err := client.Close()
+					Expect(err).NotTo(HaveOccurred())
+				}()
 
 				By("attempting to initialize without token")
 				initRequest := createInitRequest()
@@ -156,7 +165,10 @@ var _ = Describe("OAuth Integration", Ordered, func() {
 				By("making request without authorization header")
 				resp, err := http.Get(mcpServerURL)
 				Expect(err).NotTo(HaveOccurred())
-				defer resp.Body.Close()
+				defer func() {
+					err := resp.Body.Close()
+					Expect(err).NotTo(HaveOccurred())
+				}()
 
 				By("returning HTTP 401 Unauthorized")
 				Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
@@ -191,7 +203,8 @@ var _ = Describe("OAuth Integration", Ordered, func() {
 
 			AfterEach(func() {
 				if client != nil {
-					client.Close()
+					err := client.Close()
+					Expect(err).NotTo(HaveOccurred())
 				}
 			})
 
@@ -259,7 +272,8 @@ var _ = Describe("OAuth Integration", Ordered, func() {
 
 			AfterEach(func() {
 				if client != nil {
-					client.Close()
+					err := client.Close()
+					Expect(err).NotTo(HaveOccurred())
 				}
 			})
 
@@ -300,7 +314,8 @@ var _ = Describe("OAuth Integration", Ordered, func() {
 
 			AfterEach(func() {
 				if client != nil {
-					client.Close()
+					err := client.Close()
+					Expect(err).NotTo(HaveOccurred())
 				}
 			})
 
@@ -339,7 +354,10 @@ func performDirectAccessGrant(clientID, username, password string) *mcpclient.To
 
 	resp, err := http.PostForm(tokenURL, formData)
 	Expect(err).NotTo(HaveOccurred())
-	defer resp.Body.Close()
+	defer func() {
+		err := resp.Body.Close()
+		Expect(err).NotTo(HaveOccurred())
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -388,7 +406,10 @@ func performDirectAccessGrantWithScopes(clientID, username, password, scopes str
 
 	resp, err := http.PostForm(tokenURL, formData)
 	Expect(err).NotTo(HaveOccurred())
-	defer resp.Body.Close()
+	defer func() {
+		err := resp.Body.Close()
+		Expect(err).NotTo(HaveOccurred())
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -481,14 +502,16 @@ func createKeycloakCommand(args string) *exec.Cmd {
 func createMockBackendServer() *httptest.Server {
 	By("creating mock backend server")
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, `{"status": "ok"}`)
+		_, err := fmt.Fprintln(w, `{"status": "ok"}`)
+		Expect(err).NotTo(HaveOccurred())
 	}))
 }
 
 func createOAuthCallbackServer() *httptest.Server {
 	By("creating OAuth callback server")
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, "OAuth callback received")
+		_, err := fmt.Fprintf(w, "OAuth callback received")
+		Expect(err).NotTo(HaveOccurred())
 	}))
 }
 
@@ -549,7 +572,10 @@ servers:
 
 	tmpfile, err := os.CreateTemp("", "mcp-oauth-*.yaml")
 	Expect(err).NotTo(HaveOccurred())
-	defer os.Remove(tmpfile.Name())
+	defer func() {
+		err := os.Remove(tmpfile.Name())
+		Expect(err).NotTo(HaveOccurred())
+	}()
 
 	_, err = tmpfile.WriteString(mcpYAML)
 	Expect(err).NotTo(HaveOccurred())

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -23,7 +23,9 @@ func TestIntegration(t *testing.T) {
 	// 1. Create a mock HTTP server
 	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/users/123", r.URL.Path)
-		fmt.Fprintln(w, "{\"status\": \"ok\"}")
+		if _, err := fmt.Fprintln(w, `{"status": "ok"}`); err != nil {
+			t.Fatalf("failed to write response in server: %v", err)
+		}
 	}))
 	defer httpServer.Close()
 
@@ -57,7 +59,11 @@ servers:
 	// 3. Write the MCP file to a temporary file
 	tmpfile, err := os.CreateTemp("", "mcp-*.yaml")
 	require.NoError(t, err)
-	defer os.Remove(tmpfile.Name())
+	defer func() {
+		if err := os.Remove(tmpfile.Name()); err != nil {
+			t.Errorf("failed to remove temporary file %s: %v", tmpfile.Name(), err)
+		}
+	}()
 
 	_, err = tmpfile.WriteString(mcpYAML)
 	require.NoError(t, err)
@@ -169,7 +175,11 @@ servers:
 	// 2. Write the MCP file to a temporary file
 	tmpfile, err := os.CreateTemp("", "mcp-*.yaml")
 	require.NoError(t, err)
-	defer os.Remove(tmpfile.Name())
+	defer func() {
+		if err := os.Remove(tmpfile.Name()); err != nil {
+			t.Errorf("failed to remove temporary file %s: %v", tmpfile.Name(), err)
+		}
+	}()
 
 	_, err = tmpfile.WriteString(mcpYAML)
 	require.NoError(t, err)


### PR DESCRIPTION

Fixes: #69  

### Changes
- add workflow file for linting on PR and merge to main
- fix all linting errors

for reference, these were the errors:
```yaml
examples/http-conversion/feature-requests/main.go:101:28: Error return value of `(*encoding/json.Encoder).Encode` is not checked (errcheck)
		json.NewEncoder(w).Encode(map[string]string{"error": "No features found"})
		                         ^
examples/http-conversion/feature-requests/main.go:111:27: Error return value of `(*encoding/json.Encoder).Encode` is not checked (errcheck)
	json.NewEncoder(w).Encode(summary)
	                         ^
examples/http-conversion/feature-requests/main.go:119:28: Error return value of `(*encoding/json.Encoder).Encode` is not checked (errcheck)
		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid JSON"})
		                         ^
examples/http-conversion/feature-requests/main.go:243:18: Error return value of `file.Close` is not checked (errcheck)
	defer file.Close()
	                ^
examples/http-conversion/feature-requests/main.go:246:9: Error return value of `io.Copy` is not checked (errcheck)
	io.Copy(w, file)
	       ^
pkg/cli/stop.go:45:33: Error return value of `processManager.DeleteProcessId` is not checked (errcheck)
		processManager.DeleteProcessId(mcpFilePath)
		                              ^
pkg/cli/stop.go:55:32: Error return value of `processManager.DeleteProcessId` is not checked (errcheck)
	processManager.DeleteProcessId(mcpFilePath)
	                              ^
pkg/cli/utils/process_manager.go:27:16: Error return value of `f.WriteString` is not checked (errcheck)
		f.WriteString("{}")
		             ^
pkg/cli/utils/process_manager.go:28:10: Error return value of `f.Close` is not checked (errcheck)
		f.Close()
		       ^
pkg/mcpfile/tools.go:163:27: Error return value of `response.Body.Close` is not checked (errcheck)
	defer response.Body.Close()
	                         ^
pkg/oauth/middleware.go:78:9: Error return value of `w.Write` is not checked (errcheck)
	w.Write([]byte(body))
	       ^
pkg/oauth/tokenvalidator.go:203:23: Error return value of `resp.Body.Close` is not checked (errcheck)
	defer resp.Body.Close()
	                     ^
pkg/oauth/tokenvalidator.go:225:23: Error return value of `resp.Body.Close` is not checked (errcheck)
	defer resp.Body.Close()
	                     ^
test/auth_test.go:102:26: Error return value of `resp.Body.Close` is not checked (errcheck)
				defer resp.Body.Close()
				                     ^
test/auth_test.go:145:23: Error return value of `client.Close` is not checked (errcheck)
				defer client.Close()
				                  ^
test/auth_test.go:194:18: Error return value of `client.Close` is not checked (errcheck)
					client.Close()
add golangci-lint github action
					            ^
test/auth_test.go:262:18: Error return value of `client.Close` is not checked (errcheck)
					client.Close()
					            ^
test/auth_test.go:484:15: Error return value of `fmt.Fprintln` is not checked (errcheck)
		fmt.Fprintln(w, `{"status": "ok"}`)
		            ^
test/auth_test.go:491:14: Error return value of `fmt.Fprintf` is not checked (errcheck)
		fmt.Fprintf(w, "OAuth callback received")
		           ^
test/auth_test.go:552:17: Error return value of `os.Remove` is not checked (errcheck)
	defer os.Remove(tmpfile.Name())
	               ^
test/integration_test.go:26:15: Error return value of `fmt.Fprintln` is not checked (errcheck)
		fmt.Fprintln(w, "{\"status\": \"ok\"}")
		            ^
test/integration_test.go:60:17: Error return value of `os.Remove` is not checked (errcheck)
	defer os.Remove(tmpfile.Name())
	               ^
test/integration_test.go:172:17: Error return value of `os.Remove` is not checked (errcheck)
	defer os.Remove(tmpfile.Name())
	               ^
pkg/cli/utils/process_manager.go:92:2: ineffectual assignment to err (ineffassign)
	err = os.WriteFile(pm.filePath, bytes, 0644)
	^
pkg/cli/utils/process_manager.go:119:2: ineffectual assignment to err (ineffassign)
	err = os.WriteFile(pm.filePath, bytes, 0644)
	^
pkg/mcpserver/server.go:14:2: ST1019: package "github.com/mark3labs/mcp-go/server" is being imported more than once (staticcheck)
	"github.com/mark3labs/mcp-go/server"
	^
pkg/mcpserver/server.go:15:2: ST1019(related information): other import of "github.com/mark3labs/mcp-go/server" (staticcheck)
	mcpserver "github.com/mark3labs/mcp-go/server"
	^
pkg/openapi/openapi.go:44:15: ST1005: error strings should not end with punctuation or newlines (staticcheck)
		return nil, fmt.Errorf("no host provided in the swagger file, unable to construct valid URLs.")
		            ^
28 issues:
* errcheck: 23
* ineffassign: 2
* staticcheck: 3
```