### PR TITLE
feat: add release workflows (prerelease, nightly, publish)

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -1,0 +1,152 @@
+name: Create Pre-Release
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'release/v*.*'
+jobs:
+  determine-version:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/heads/release/v')
+    permissions:
+      contents: write
+    outputs:
+      prerelease_version: ${{ env.PRERELEASE_VERSION }}
+      skip_prerelease: ${{ env.SKIP_PRERELEASE }}
+      changelog_body: ${{ env.CHANGELOG_BODY }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Extract version and determine z version
+        id: get_version
+        run: |
+          BRANCH_NAME="${{ github.ref_name }}"
+          BASE_VERSION=$(echo "${BRANCH_NAME}" | sed 's/release\/v/v/')
+          
+          # Find the latest release tag for this x.y version
+          LATEST_RELEASE=$(git tag -l "${BASE_VERSION}.*" --sort=-version:refname | head -n1)
+          
+          if [ -z "$LATEST_RELEASE" ]; then
+            # No existing releases for this x.y version, start with z=0
+            Z_VERSION="0"
+            echo "No existing releases found for ${BASE_VERSION}, starting with z=0"
+          else
+            # Check if there are new commits since the latest release
+            COMMITS_SINCE_RELEASE=$(git rev-list ${LATEST_RELEASE}..HEAD --count)
+            
+            if [ "$COMMITS_SINCE_RELEASE" -eq "0" ]; then
+              echo "No new commits since ${LATEST_RELEASE}, skipping prerelease creation"
+              echo "SKIP_PRERELEASE=true" >> "$GITHUB_ENV"
+              exit 0
+            fi
+            
+            # Extract z version from latest release and increment
+            LATEST_Z=$(echo "$LATEST_RELEASE" | sed "s/${BASE_VERSION}\.//")
+            Z_VERSION=$((LATEST_Z + 1))
+            echo "Found ${COMMITS_SINCE_RELEASE} new commits since ${LATEST_RELEASE}, incrementing to z=${Z_VERSION}"
+          fi
+          
+          PRERELEASE_VERSION="${BASE_VERSION}.${Z_VERSION}-prerelease"
+          echo "PRERELEASE_VERSION=$PRERELEASE_VERSION" >> "$GITHUB_ENV"
+          echo "Creating prerelease: $PRERELEASE_VERSION"
+
+      - name: Extract changelog
+        id: changelog
+        if: env.SKIP_PRERELEASE != 'true'
+        run: |
+          # Extract the z release version from the prerelease version
+          RELEASE_VERSION=$(echo "${{ env.PRERELEASE_VERSION }}" | sed 's/-prerelease//')
+          
+          # Try to extract the changelog section for this release version
+          CHANGELOG_CONTENT=$(sed -n "/## \[${RELEASE_VERSION}\]/,/## \[/p" CHANGELOG.md | sed '$d' | tail -n +2 | awk '/^### /{section=$0; items=""; next} /^( *)?- /{items=items $0 "\n"; next} /^$/ && items{print section "\n" items; items=""}' | sed '/^$/d')
+          
+          # If no specific version section found, provide a default prerelease message
+          if [ -z "$CHANGELOG_CONTENT" ]; then
+            CHANGELOG_CONTENT="Pre-release build for ${RELEASE_VERSION}. See CHANGELOG.md for details."
+          fi
+          
+          # Save to environment variable, handling multiline content
+          {
+            echo 'CHANGELOG_BODY<<EOF'
+            echo "$CHANGELOG_CONTENT"
+            echo 'EOF'
+          } >> "$GITHUB_ENV"
+
+      - name: Create or update draft release
+        if: env.SKIP_PRERELEASE != 'true'
+        run: |
+          VERSION="${{ env.PRERELEASE_VERSION }}"
+          
+          # Check if release already exists
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            echo "Release $VERSION already exists, updating with latest changelog..."
+            gh release edit "$VERSION" \
+              --title "$VERSION" \
+              --notes "${{ env.CHANGELOG_BODY }}" \
+              --draft \
+              --prerelease
+          else
+            echo "Creating new draft pre-release $VERSION..."
+            gh release create "$VERSION" \
+              --title "$VERSION" \
+              --notes "${{ env.CHANGELOG_BODY }}" \
+              --draft \
+              --prerelease
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-and-upload:
+    needs: determine-version
+    if: needs.determine-version.outputs.skip_prerelease != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        goos: [linux, windows, darwin]
+        goarch: [amd64, arm64]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.4'
+
+      - name: Build genmcp
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          VERSION_TAG: ${{ needs.determine-version.outputs.prerelease_version }}
+        run: |
+          CLI_NAME="genmcp"
+          if [ "${GOOS}" == "windows" ]; then
+            OUTPUT_NAME="${CLI_NAME}-${GOOS}-${GOARCH}.exe"
+          else
+            OUTPUT_NAME="${CLI_NAME}-${GOOS}-${GOARCH}"
+          fi
+
+          go build -o "${OUTPUT_NAME}" -ldflags="-X 'main.version=${VERSION_TAG}'" ./cmd/genmcp
+
+          if [ "${GOOS}" == "windows" ]; then
+            zip "${CLI_NAME}-${GOOS}-${GOARCH}.zip" "${OUTPUT_NAME}"
+          else
+            zip "${CLI_NAME}-${GOOS}-${GOARCH}.zip" "${OUTPUT_NAME}"
+          fi
+
+      - name: Upload assets to release
+        run: |
+          VERSION="${{ needs.determine-version.outputs.prerelease_version }}"
+          
+          # Upload assets
+          for file in *.zip; do
+            if [ -f "$file" ]; then
+              gh release upload "$VERSION" "$file" --clobber
+            fi
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -1,0 +1,158 @@
+name: Nightly Release
+
+on:
+  schedule:
+    # Run at 02:00 UTC every day
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  check-and-create-nightly:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      nightly_version: ${{ env.NIGHTLY_VERSION }}
+      skip_nightly: ${{ env.SKIP_NIGHTLY }}
+      changelog_body: ${{ env.CHANGELOG_BODY }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for unreleased commits
+        id: check_commits
+        run: |
+          # Find the latest release tag (any x.y.z release)
+          LATEST_RELEASE=$(git tag -l 'v*.*.*' --sort=-version:refname | grep -v 'prerelease' | grep -v 'nightly' | head -n1)
+          
+          if [ -z "$LATEST_RELEASE" ]; then
+            echo "No existing releases found, creating first nightly"
+            COMMITS_SINCE_RELEASE=$(git rev-list HEAD --count)
+            LATEST_RELEASE_COMMIT=""
+          else
+            echo "Latest release: $LATEST_RELEASE"
+            COMMITS_SINCE_RELEASE=$(git rev-list ${LATEST_RELEASE}..HEAD --count)
+            LATEST_RELEASE_COMMIT="$LATEST_RELEASE"
+          fi
+          
+          echo "Commits since latest release: $COMMITS_SINCE_RELEASE"
+          
+          if [ "$COMMITS_SINCE_RELEASE" -eq "0" ]; then
+            echo "No new commits since latest release, skipping nightly"
+            echo "SKIP_NIGHTLY=true" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          
+          # Check if there's already a nightly for today's commits
+          TODAY=$(date -u +%Y%m%d)
+          CURRENT_COMMIT=$(git rev-parse HEAD)
+          SHORT_COMMIT=$(git rev-parse --short HEAD)
+          
+          # Check for existing nightly with same commit
+          EXISTING_NIGHTLY=$(git tag -l "*nightly*" | while read tag; do
+            if [ -n "$tag" ]; then
+              tag_commit=$(git rev-list -n 1 "$tag" 2>/dev/null || echo "")
+              if [ "$tag_commit" = "$CURRENT_COMMIT" ]; then
+                echo "$tag"
+                break
+              fi
+            fi
+          done)
+          
+          if [ -n "$EXISTING_NIGHTLY" ]; then
+            echo "Nightly release already exists for current commit: $EXISTING_NIGHTLY"
+            echo "SKIP_NIGHTLY=true" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          
+          # Create nightly version
+          NIGHTLY_VERSION="nightly-${TODAY}-${SHORT_COMMIT}"
+          echo "NIGHTLY_VERSION=$NIGHTLY_VERSION" >> "$GITHUB_ENV"
+          echo "Creating nightly release: $NIGHTLY_VERSION"
+
+      - name: Extract changelog for nightly
+        id: changelog
+        if: env.SKIP_NIGHTLY != 'true'
+        run: |
+          # Extract the Unreleased section from CHANGELOG.md
+          CHANGELOG_CONTENT=$(sed -n '/## \[Unreleased\]/,/## \[/p' CHANGELOG.md | sed '$d' | tail -n +2 | awk '/^### /{section=$0; items=""; next} /^( *)?- /{items=items $0 "\n"; next} /^$/ && items{print section "\n" items; items=""}' | sed '/^$/d')
+          
+          # If changelog content is empty, provide a default message
+          if [ -z "$CHANGELOG_CONTENT" ]; then
+            CHANGELOG_CONTENT="See CHANGELOG.md for details."
+          fi
+          
+          # Save to environment variable, handling multiline content
+          {
+            echo 'CHANGELOG_BODY<<EOF'
+            echo "$CHANGELOG_CONTENT"
+            echo 'EOF'
+          } >> "$GITHUB_ENV"
+
+      - name: Create nightly release
+        if: env.SKIP_NIGHTLY != 'true'
+        run: |
+          VERSION="${{ env.NIGHTLY_VERSION }}"
+          
+          echo "Creating nightly release: $VERSION"
+          gh release create "$VERSION" \
+            --title "Nightly Release $VERSION" \
+            --notes "${{ env.CHANGELOG_BODY }}" \
+            --prerelease
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-and-upload:
+    needs: check-and-create-nightly
+    if: needs.check-and-create-nightly.outputs.skip_nightly != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        goos: [linux, windows, darwin]
+        goarch: [amd64, arm64]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.4'
+
+      - name: Build genmcp
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          VERSION_TAG: ${{ needs.check-and-create-nightly.outputs.nightly_version }}
+        run: |
+          CLI_NAME="genmcp"
+          if [ "${GOOS}" == "windows" ]; then
+            OUTPUT_NAME="${CLI_NAME}-${GOOS}-${GOARCH}.exe"
+          else
+            OUTPUT_NAME="${CLI_NAME}-${GOOS}-${GOARCH}"
+          fi
+
+          go build -o "${OUTPUT_NAME}" -ldflags="-X 'main.version=${VERSION_TAG}'" ./cmd/genmcp
+
+          if [ "${GOOS}" == "windows" ]; then
+            zip "${CLI_NAME}-${GOOS}-${GOARCH}.zip" "${OUTPUT_NAME}"
+          else
+            zip "${CLI_NAME}-${GOOS}-${GOARCH}.zip" "${OUTPUT_NAME}"
+          fi
+
+      - name: Upload assets to nightly release
+        run: |
+          VERSION="${{ needs.check-and-create-nightly.outputs.nightly_version }}"
+          
+          # Upload assets
+          for file in *.zip; do
+            if [ -f "$file" ]; then
+              gh release upload "$VERSION" "$file" --clobber
+            fi
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -1,0 +1,170 @@
+name: Publish Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_branch:
+        description: 'Release branch (e.g., release/v1.0)'
+        required: true
+        type: string
+
+jobs:
+  determine-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ env.VERSION }}
+      changelog_body: ${{ env.CHANGELOG_BODY }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.release_branch }}
+
+      - name: Validate release branch format
+        run: |
+          if [[ ! "${{ inputs.release_branch }}" =~ ^release/v[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Release branch must match format 'release/vX.Y'"
+            exit 1
+          fi
+
+      - name: Extract version and determine z version
+        id: get_version
+        run: |
+          BRANCH_NAME="${{ inputs.release_branch }}"
+          BASE_VERSION=$(echo "${BRANCH_NAME}" | sed 's/release\/v/v/')
+          
+          # Find the latest release tag for this x.y version
+          LATEST_RELEASE=$(git tag -l "${BASE_VERSION}.*" --sort=-version:refname | head -n1)
+          
+          if [ -z "$LATEST_RELEASE" ]; then
+            # No existing releases for this x.y version, start with z=0
+            Z_VERSION="0"
+            echo "No existing releases found for ${BASE_VERSION}, starting with z=0"
+          else
+            # Extract z version from latest release and increment
+            LATEST_Z=$(echo "$LATEST_RELEASE" | sed "s/${BASE_VERSION}\.//")
+            Z_VERSION=$((LATEST_Z + 1))
+            echo "Latest release: ${LATEST_RELEASE} (z=${LATEST_Z}), incrementing to z=${Z_VERSION}"
+          fi
+          
+          VERSION="${BASE_VERSION}.${Z_VERSION}"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "Release version: $VERSION"
+
+      - name: Validate CHANGELOG has version section
+        run: |
+          VERSION="${{ env.VERSION }}"
+          if ! grep -q "## \[${VERSION}\]" CHANGELOG.md; then
+            echo "Error: CHANGELOG.md must contain a section for version ${VERSION}"
+            echo "Expected format: ## [${VERSION}]"
+            echo "Current CHANGELOG sections:"
+            grep "^## \[" CHANGELOG.md || echo "No version sections found"
+            exit 1
+          fi
+          echo "CHANGELOG validation passed for version ${VERSION}"
+
+      - name: Extract changelog for release
+        id: changelog
+        run: |
+          VERSION="${{ env.VERSION }}"
+          # Extract the specific version section from CHANGELOG.md
+          CHANGELOG_CONTENT=$(sed -n "/## \[${VERSION}\]/,/## \[/p" CHANGELOG.md | sed '$d' | tail -n +2 | awk '/^### /{section=$0; items=""; next} /^( *)?- /{items=items $0 "\n"; next} /^$/ && items{print section "\n" items; items=""}' | sed '/^$/d')
+          
+          # If changelog content is empty, provide a default message
+          if [ -z "$CHANGELOG_CONTENT" ]; then
+            CHANGELOG_CONTENT="See CHANGELOG.md for details."
+          fi
+          
+          # Save to environment variable, handling multiline content
+          {
+            echo 'CHANGELOG_BODY<<EOF'
+            echo "$CHANGELOG_CONTENT"
+            echo 'EOF'
+          } >> "$GITHUB_ENV"
+
+      - name: Run tests
+        run: |
+          echo "Running all tests..."
+          go test ./...
+          echo "All tests passed!"
+
+      - name: Publish release
+        run: |
+          VERSION="${{ env.VERSION }}"
+          PRERELEASE_TAG="${VERSION}-prerelease"
+          
+          # Check if a pre-release exists and update it, otherwise create new release
+          if gh release view "$PRERELEASE_TAG" >/dev/null 2>&1; then
+            echo "Found existing pre-release: $PRERELEASE_TAG, updating to final release..."
+            gh release edit "$PRERELEASE_TAG" \
+              --tag "$VERSION" \
+              --title "$VERSION" \
+              --notes "${{ env.CHANGELOG_BODY }}" \
+              --draft=false \
+              --prerelease=false \
+              --latest
+          else
+            echo "No existing pre-release found, creating new release..."
+            gh release create "$VERSION" \
+              --title "$VERSION" \
+              --notes "${{ env.CHANGELOG_BODY }}" \
+              --latest
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-and-upload:
+    needs: determine-version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        goos: [linux, windows, darwin]
+        goarch: [amd64, arm64]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.release_branch }}
+
+      - name: Set up go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.4'
+
+      - name: Build genmcp
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          VERSION_TAG: ${{ needs.determine-version.outputs.version }}
+        run: |
+          CLI_NAME="genmcp"
+          if [ "${GOOS}" == "windows" ]; then
+            OUTPUT_NAME="${CLI_NAME}-${GOOS}-${GOARCH}.exe"
+          else
+            OUTPUT_NAME="${CLI_NAME}-${GOOS}-${GOARCH}"
+          fi
+
+          go build -o "${OUTPUT_NAME}" -ldflags="-X 'main.version=${VERSION_TAG}'" ./cmd/genmcp
+
+          if [ "${GOOS}" == "windows" ]; then
+            zip "${CLI_NAME}-${GOOS}-${GOARCH}.zip" "${OUTPUT_NAME}"
+          else
+            zip "${CLI_NAME}-${GOOS}-${GOARCH}.zip" "${OUTPUT_NAME}"
+          fi
+
+      - name: Upload assets to release
+        run: |
+          VERSION="${{ needs.determine-version.outputs.version }}"
+          
+          # Upload assets
+          for file in *.zip; do
+            if [ -f "$file" ]; then
+              gh release upload "$VERSION" "$file" --clobber
+            fi
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [v0.0.0]
+
+### Added
+- Initial MCP File specification
+- Simple converter to convert OpenAPI v2/v3 specifications into the MCP file format
+- Initial MCP Server implementation
+  - Reads from the MCP file and runs a server with the provided tools
+  - OAuth 2.0/OIDC support for the MCP Client -> MCP Server connection
+- Initial genmcp CLI implementation
+  - genmcp run will run servers from the MCP files
+  - genmcp stop will stop servers
+  - genmcp convert converts an OpenAPI spec to an mcp file
+- Initial examples
+  - CLI/HTTP examples with ollama
+  - HTTP conversion examples and integrations with multiple tools
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security


### PR DESCRIPTION
This PR adds release workflows to:
1. Automatically create a prerelease whenever a new `release/vx.y` branch is created, using the related section in the CHANGELOG.md file to create release notes (if it exists yet).
2. Create a real release whenever a user runs the publish release workflow with the `release/vx.y` set. This allows for manual checking of pre-releases, and choosing when we have backported the right set of commits for a z release
3. Create nightly releases if there are unreleased commits on `main`

Some example releases created when I committed these actions to `main` on my fork are:
- https://github.com/Cali0707/gen-mcp/releases/tag/v0.0.0
- https://github.com/Cali0707/gen-mcp/releases/tag/untagged-b2832e978cd0ab36c53e
Note that for v0.0.0, there is a CHANGELOG entry, but v0.1.0 does not have one yet. This leads to the different release notes. For v0.0.0, I also ran the publish-release action, so that it is not marked as a prerelease.