### PR TITLE
fix: individual tool errors in OpenAPI conversion do not block mcpfile creation

### DIFF
--- a/pkg/openapi/openapi.go
+++ b/pkg/openapi/openapi.go
@@ -176,10 +176,18 @@ func McpFileFromOpenApiV2Model(model *v2high.Swagger, host string) (*mcpfile.MCP
 		}
 	}
 
-	validationErr := server.Validate(invocation.InvocationValidator)
-	if validationErr != nil {
-		err = errors.Join(err, fmt.Errorf("failed to validate converted server: %w", validationErr))
+	// the only errors we should see at this point are from the tools themselves - let's validate them and filter out invalid tools
+	validTools := make([]*mcpfile.Tool, 0, len(server.Tools))
+	for _, t := range server.Tools {
+		toolErr := t.Validate(invocation.InvocationValidator)
+		if toolErr != nil {
+			err = errors.Join(err, fmt.Errorf("skipping tool %s: %w", t.Name, toolErr))
+		} else {
+			validTools = append(validTools, t)
+		}
 	}
+
+	server.Tools = validTools
 
 	res.Servers = []*mcpfile.MCPServer{server}
 
@@ -309,10 +317,18 @@ func McpFileFromOpenApiV3Model(model *v3high.Document, host string) (*mcpfile.MC
 		}
 	}
 
-	validationErr := server.Validate(invocation.InvocationValidator)
-	if validationErr != nil {
-		return nil, errors.Join(err, fmt.Errorf("failed to validate converted server: %w", validationErr))
+	// the only errors we should see at this point are from the tools themselves - let's validate them and filter out invalid tools
+	validTools := make([]*mcpfile.Tool, 0, len(server.Tools))
+	for _, t := range server.Tools {
+		toolErr := t.Validate(invocation.InvocationValidator)
+		if toolErr != nil {
+			err = errors.Join(err, fmt.Errorf("skipping tool %s: %w", t.Name, toolErr))
+		} else {
+			validTools = append(validTools, t)
+		}
 	}
+
+	server.Tools = validTools
 
 	res.Servers = []*mcpfile.MCPServer{server}
 

--- a/pkg/openapi/openapi_test.go
+++ b/pkg/openapi/openapi_test.go
@@ -32,3 +32,52 @@ func TestDefaultPort8080InOpenAPIV3Conversion(t *testing.T) {
 	server := mcpfile.Servers[0]
 	assert.Equal(t, 8080, server.Runtime.StreamableHTTPConfig.Port, "OpenAPI v3 conversion should default to port 8080")
 }
+
+func TestInvalidToolsAreSkippedButValidOnesIncluded(t *testing.T) {
+	docBytes, _ := os.ReadFile("testdata/openapi_with_invalid_tools.json")
+
+	mcpfile, err := DocumentToMcpFile(docBytes, "")
+
+	// We should get an error about the invalid tool but still get a valid MCP file
+	assert.Error(t, err, "conversion should report errors about invalid tools")
+	assert.NotNil(t, mcpfile, "MCP file should still be generated")
+	assert.Len(t, mcpfile.Servers, 1, "should have one server")
+
+	server := mcpfile.Servers[0]
+	assert.NotNil(t, server.Tools, "server should have tools")
+
+	// Should have exactly 2 valid tools (the ones with descriptions)
+	assert.Len(t, server.Tools, 2, "should have exactly 2 valid tools")
+
+	// Check that the valid tools are present
+	toolNames := make([]string, len(server.Tools))
+	for i, tool := range server.Tools {
+		toolNames[i] = tool.Name
+		assert.NotEmpty(t, tool.Description, "all included tools should have descriptions")
+	}
+
+	assert.Contains(t, toolNames, "get_valid-endpoint", "should include the valid GET endpoint")
+	assert.Contains(t, toolNames, "post_another-valid-endpoint", "should include the valid POST endpoint")
+
+	// Check that the error message contains information about the skipped tool
+	assert.Contains(t, err.Error(), "get_invalid-endpoint", "error should mention the skipped tool")
+	assert.Contains(t, err.Error(), "description is required", "error should mention why the tool was skipped")
+}
+
+func TestAllToolsInvalidStillReturnsEmptyMcpFile(t *testing.T) {
+	docBytes, _ := os.ReadFile("testdata/openapi_all_invalid_tools.json")
+
+	mcpfile, err := DocumentToMcpFile(docBytes, "")
+
+	// Should get an error about all invalid tools
+	assert.Error(t, err, "conversion should report errors about all invalid tools")
+	assert.NotNil(t, mcpfile, "MCP file should still be generated")
+	assert.Len(t, mcpfile.Servers, 1, "should have one server")
+
+	server := mcpfile.Servers[0]
+	assert.Empty(t, server.Tools, "server should have no tools when all are invalid")
+
+	// Check that error mentions both skipped tools
+	assert.Contains(t, err.Error(), "get_no-description-1", "error should mention first skipped tool")
+	assert.Contains(t, err.Error(), "post_no-description-2", "error should mention second skipped tool")
+}

--- a/pkg/openapi/testdata/openapi_all_invalid_tools.json
+++ b/pkg/openapi/testdata/openapi_all_invalid_tools.json
@@ -1,0 +1,36 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "All Invalid Tools API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.example.com"
+    }
+  ],
+  "paths": {
+    "/no-description-1": {
+      "get": {
+        "summary": "No description endpoint 1",
+        "operationId": "getNoDescription1",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/no-description-2": {
+      "post": {
+        "summary": "No description endpoint 2",
+        "operationId": "postNoDescription2",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    }
+  }
+}

--- a/pkg/openapi/testdata/openapi_with_invalid_tools.json
+++ b/pkg/openapi/testdata/openapi_with_invalid_tools.json
@@ -1,0 +1,64 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test API with Invalid Tools",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.example.com"
+    }
+  ],
+  "paths": {
+    "/valid-endpoint": {
+      "get": {
+        "summary": "Valid endpoint",
+        "description": "This endpoint has a proper description",
+        "operationId": "getValidEndpoint",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/invalid-endpoint": {
+      "get": {
+        "summary": "Invalid endpoint without description",
+        "operationId": "getInvalidEndpoint",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/another-valid-endpoint": {
+      "post": {
+        "summary": "Another valid endpoint",
+        "description": "This endpoint also has a proper description",
+        "operationId": "postAnotherValidEndpoint",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Resolves #94 

This PR changes our mcp server validation logic. As the MCP server should have a valid name, version, runtime by the time the conversion is finished all we need to do is validate individual tools.

By moving to individual tool validation, we are able to report errors to users as well as filter out invalid tools as was discussed on #94 