### PR TITLE
fix(example): correct oauth example ports

### DIFF
--- a/examples/http-conversion/oauth-mcpfile.yaml
+++ b/examples/http-conversion/oauth-mcpfile.yaml
@@ -3,7 +3,7 @@ servers:
 - name: Feature Request API
   runtime:
     streamableHttpConfig:
-      port: 8080
+      port: 7007
       auth:
         authorizationServers:
           - http://localhost:8080/realms/master


### PR DESCRIPTION
In the OAuth example, the MCP server is set to run on port 8080. Unfortunately, that is incorrect as that port is being used by keycloak in this example.

This PR switches the MCP server to start on 7007 instead, avoiding the conflict