### PR TITLE
feat: add version command to cli

### DIFF
--- a/cmd/genmcp/main.go
+++ b/cmd/genmcp/main.go
@@ -4,6 +4,8 @@ import (
 	"github.com/genmcp/gen-mcp/pkg/cli"
 )
 
+var version string
+
 func main() {
-	cli.Execute()
+	cli.Execute(version)
 }

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -46,7 +46,11 @@ func getDevVersion() devVersion {
 		for _, setting := range info.Settings {
 			switch setting.Key {
 			case "vcs.revision":
-				dv.commit = setting.Value
+				if len(setting.Value) >= 7 {
+                   dv.commit = setting.Value[:7]
+               } else {
+                  dv.commit = setting.Value
+               }
 			case "vcs.modified":
 				dv.hasUncommitedChanges = setting.Value == "true"
 			}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -7,12 +7,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var cliVersion string
+
 var rootCmd = &cobra.Command{
 	Use:   "genmcp",
 	Short: "genmcp manages gen-mcp servers, and their configuration",
 }
 
-func Execute() {
+func Execute(version string) {
+	if version == "" {
+		cliVersion = "development"
+	} else {
+		cliVersion = version
+	}
+
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -1,0 +1,28 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print GenMCP's version",
+	Run:   executeVersionCmd,
+}
+
+func executeVersionCmd(cobraCmd *cobra.Command, args []string) {
+	err := cobra.NoArgs(cobraCmd, args)
+	if err != nil {
+		fmt.Printf("%s\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("genmcp version %s\n", cliVersion)
+}


### PR DESCRIPTION
Resolves #85 

This PR allows for setting the version of the CLI while building it (falling back to `development`).

We already [build the CLI correctly with the version tag embedded in the release workflows](https://github.com/genmcp/gen-mcp/blob/39cb82ee469119280c4c8c4468df820aa8d9e710/.github/workflows/create-release.yaml#L135), I just was not familiar with how that all worked when I set those up so I unfortunately did not use the value within the CLI for a version command.

This PR adds a new version command that uses the version.

## Examples
Without setting the version:
```bash
$ go build ./cmd/genmcp
$ ./genmcp version
genmcp version development
```

Setting the version:
```bash
$ go build -ldflags "-X main.version=v0.1.0" ./cmd/genmcp
$ ./genmcp version
genmcp version v0.1.0
```