### PR TITLE
fix: tool input schemas have the properties serialize to {} when empty

### DIFF
--- a/pkg/mcpfile/parser.go
+++ b/pkg/mcpfile/parser.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	"sigs.k8s.io/yaml"
 )
 
@@ -85,6 +86,11 @@ func (t *Tool) UnmarshalJSON(data []byte) error {
 	err := json.Unmarshal(data, &tmp)
 	if err != nil {
 		return err
+	}
+
+	if t.InputSchema.Properties == nil {
+		// set the properties to be not nil so that it serializes as {} (required for some clients to properly parse the tool)
+		t.InputSchema.Properties = make(map[string]*jsonschema.Schema)
 	}
 
 	if len(tmp.Invocation) != 1 {


### PR DESCRIPTION
@matzew reported running into problems with MCP interviewer with some of our tools. We think it is because when the schema is type `Object` (which all top-level schemas are), and there are no properties it still tries to parse the properties. 

This PR fixes this parsing by making the map non-nil so that it will serialize to `{}` when sent as JSON through the transport.