### PR TITLE
Don't set SELinux flag when mounting volumes on podman for mac

### DIFF
--- a/hack/lib/keycloak.sh
+++ b/hack/lib/keycloak.sh
@@ -7,6 +7,13 @@ readonly KEYCLOAK_ADMIN="admin"
 readonly KEYCLOAK_ADMIN_PASSWORD="admin"
 readonly KEYCLOAK_CONTAINER_NAME="keycloak"
 readonly TRUSTSTORE_PASS="password"
+# Set volume mount flags conditionally based on OS
+# On macOS with podman, don't set the SELinux label
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  readonly VOLUME_MOUNT_FLAGS=""
+else
+  readonly VOLUME_MOUNT_FLAGS=":z"
+fi
 
 function show_keycloak_help() {
   cat << EOF
@@ -106,7 +113,7 @@ function start_keycloak() {
     -p 8443:8443 \
     -p 8081:8080 \
     -p 9000:9000 \
-    -v "${KEYCLOAK_CERTS}:/opt/keycloak/conf/certs" \
+    -v "${KEYCLOAK_CERTS}:/opt/keycloak/conf/certs${VOLUME_MOUNT_FLAGS}" \
     -e KC_BOOTSTRAP_ADMIN_USERNAME=${KEYCLOAK_ADMIN} \
     -e KC_BOOTSTRAP_ADMIN_PASSWORD=${KEYCLOAK_ADMIN_PASSWORD} \
     -e KC_HOSTNAME=localhost \


### PR DESCRIPTION
Using the less restrictive `:z` option (instead of `:Z`), and not applying it on mac - since relevant for SELinux

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Keycloak container now mounts TLS certificates correctly on Linux systems with SELinux, reducing startup failures and permission errors.
  - macOS behavior remains unchanged to maintain compatibility.

- Chores
  - Adjusted volume mount flags to improve cross-platform reliability when running the Keycloak container locally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->