### PR TITLE
Use more standardized `CONTAINER_ENGINE` 

### DIFF
--- a/hack/lib/common.sh
+++ b/hack/lib/common.sh
@@ -13,13 +13,12 @@ function header_text {
 	echo "$header$*$reset"
 }
 
-if command -v docker &> /dev/null; then
-	header_text "using docker to interact with keycloak containers"
-	CONTAINER_RUNTIME="docker"
-elif command -v podman &> /dev/null; then
-	header_text "using podman to interact with keycloak containers"
-	CONTAINER_RUNTIME="podman"
-else
-	header_text "neither docker nor podman installed on system, unable to interact with containers"
-	exit 1
+if [ -z "$CONTAINER_ENGINE" ]; then
+  if command -v podman &> /dev/null; then
+  		CONTAINER_ENGINE="podman"
+	elif command -v docker &> /dev/null; then
+		CONTAINER_ENGINE="docker"
+	else
+		abort "neither docker nor podman installed on system, unable to interact with containers"
+	fi
 fi


### PR DESCRIPTION
Like in other repos (E.g. openshift/release), assume the presence of `CONTAINER_ENGINE` (and default to either `podman` or `docker`). 

Also renamed `CONTAINER_RUNTIME` to `CONTAINER_ENGINE` (is imo wider used)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized container engine configuration across local cluster and identity scripts.
  * Unified all container operations to use a single configurable engine setting.

* **Chores**
  * If unset, the engine is auto-detected (preferring podman, then docker); aborts if neither found.
  * Users may override the engine via environment configuration.
  * No expected change to user-facing behavior or outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->