### PR TITLE
Improve keycloak container experience for kind on linux with docker

### DIFF
--- a/hack/create-kind-cluster.sh
+++ b/hack/create-kind-cluster.sh
@@ -13,6 +13,11 @@ NODE_SHA=${NODE_SHA:-"sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e
 KEYCLOAK_SVC_NAME="external-keycloak"
 KEYCLOAK_SVC_NAMESPACE="default"
 
+# Set KIND provider for podman on Linux
+if [ "$(uname -s)" != "Darwin" ] && [ "$CONTAINER_ENGINE" = "podman" ]; then
+  export KIND_EXPERIMENTAL_PROVIDER=podman
+fi
+
 # create keycloak container unless it already exists
 if [ "$($CONTAINER_ENGINE inspect -f '{{.State.Running}}' "${KEYCLOAK_CONTAINER_NAME}" 2>/dev/null || true)" != 'true' ]; then
   header_text "No keycloak container found. Will create one..."
@@ -20,6 +25,8 @@ if [ "$($CONTAINER_ENGINE inspect -f '{{.State.Running}}' "${KEYCLOAK_CONTAINER_
 else
   header_text "Keycloak container exists already. Skipping Keycloak setup..."
 fi
+
+
 
 # Create KinD cluster
 cat <<EOF | kind create cluster --config=-

--- a/hack/lib/keycloak.sh
+++ b/hack/lib/keycloak.sh
@@ -109,7 +109,7 @@ function start_keycloak() {
   fi
   
   # Start Keycloak container with TLS and HTTP
-  $CONTAINER_ENGINE run -d --name ${KEYCLOAK_CONTAINER_NAME} \
+  $CONTAINER_ENGINE run -d --net=bridge --name ${KEYCLOAK_CONTAINER_NAME} \
     -p 8443:8443 \
     -p 8081:8080 \
     -p 9000:9000 \


### PR DESCRIPTION
Improve keycloak :key: container :whale: experience for kind on linux :penguin: with podman :seal: 

* running the container to the bridge network (as like done on kind sample for registry), like: https://github.com/kubernetes-sigs/kind/pull/3407
* using experimental provider for podman, for rootless: https://kind.sigs.k8s.io/docs/user/rootless/#creating-a-kind-cluster-with-rootless-podman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved Linux compatibility for local cluster setup when using Podman, automatically selecting the appropriate provider.
- Bug Fixes
  - Enhanced Keycloak container networking to prevent connectivity issues on some environments.
- Chores
  - Minor script formatting cleanup for readability.
  - No changes to existing cluster configuration or container creation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->