### PR TITLE
Bump MCP Go-sdk to 1.0.0 release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/invopop/jsonschema v0.13.0
 	github.com/joho/godotenv v1.5.1
 	github.com/lestrrat-go/jwx/v3 v3.0.11
-	github.com/modelcontextprotocol/go-sdk v0.8.0
+	github.com/modelcontextprotocol/go-sdk v1.0.0
 	github.com/onsi/ginkgo/v2 v2.25.3
 	github.com/onsi/gomega v1.38.2
 	github.com/openai/openai-go/v2 v2.6.0

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ github.com/lestrrat-go/option/v2 v2.0.0 h1:XxrcaJESE1fokHy3FpaQ/cXW8ZsIdWcdFzzLO
 github.com/lestrrat-go/option/v2 v2.0.0/go.mod h1:oSySsmzMoR0iRzCDCaUfsCzxQHUEuhOViQObyy7S6Vg=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/modelcontextprotocol/go-sdk v0.8.0 h1:jdsBtGzBLY287WKSIjYovOXAqtJkP+HtFQFKrZd4a6c=
-github.com/modelcontextprotocol/go-sdk v0.8.0/go.mod h1:nYtYQroQ2KQiM0/SbyEPUWQ6xs4B95gJjEalc9AQyOs=
+github.com/modelcontextprotocol/go-sdk v1.0.0 h1:Z4MSjLi38bTgLrd/LjSmofqRqyBiVKRyQSJgw8q8V74=
+github.com/modelcontextprotocol/go-sdk v1.0.0/go.mod h1:nYtYQroQ2KQiM0/SbyEPUWQ6xs4B95gJjEalc9AQyOs=
 github.com/onsi/ginkgo/v2 v2.25.3 h1:Ty8+Yi/ayDAGtk4XxmmfUy4GabvM+MegeB4cDLRi6nw=
 github.com/onsi/ginkgo/v2 v2.25.3/go.mod h1:43uiyQC4Ed2tkOzLsEYm7hnrb7UJTWHYNsuy3bG/snE=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=

--- a/vendor/github.com/modelcontextprotocol/go-sdk/mcp/server.go
+++ b/vendor/github.com/modelcontextprotocol/go-sdk/mcp/server.go
@@ -380,7 +380,7 @@ func setSchema[T any](sfield *any, rfield **jsonschema.Resolved) (zero any, err 
 // If the tool's input schema is nil, it is set to the schema inferred from the
 // In type parameter. Types are inferred from Go types, and property
 // descriptions are read from the 'jsonschema' struct tag. Internally, the SDK
-// uses the github.com/google/jsonschema-go package for ineference and
+// uses the github.com/google/jsonschema-go package for inference and
 // validation. The In type argument must be a map or a struct, so that its
 // inferred JSON Schema has type "object", as required by the spec. As a
 // special case, if the In type is 'any', the tool's input schema is set to an
@@ -498,6 +498,9 @@ func (s *Server) changeAndNotify(notification string, params Params, change func
 }
 
 // Sessions returns an iterator that yields the current set of server sessions.
+//
+// There is no guarantee that the iterator observes sessions that are added or
+// removed during iteration.
 func (s *Server) Sessions() iter.Seq[*ServerSession] {
 	s.mu.Lock()
 	clients := slices.Clone(s.sessions)

--- a/vendor/github.com/modelcontextprotocol/go-sdk/mcp/transport.go
+++ b/vendor/github.com/modelcontextprotocol/go-sdk/mcp/transport.go
@@ -104,8 +104,12 @@ func (t *InMemoryTransport) Connect(context.Context) (Connection, error) {
 	return newIOConn(t.rwc), nil
 }
 
-// NewInMemoryTransports returns two [InMemoryTransports] that connect to each
-// other.
+// NewInMemoryTransports returns two [InMemoryTransport] objects that connect
+// to each other.
+//
+// The resulting transports are symmetrical: use either to connect to a server,
+// and then the other to connect to a client. Servers must be connected before
+// clients, as the client initializes the MCP session during connection.
 func NewInMemoryTransports() (*InMemoryTransport, *InMemoryTransport) {
 	c1, c2 := net.Pipe()
 	return &InMemoryTransport{c1}, &InMemoryTransport{c2}
@@ -230,7 +234,7 @@ func (s *loggingConn) Read(ctx context.Context) (jsonrpc.Message, error) {
 
 	if err != nil {
 		s.mu.Lock()
-		fmt.Fprintf(s.w, "read error: %v", err)
+		fmt.Fprintf(s.w, "read error: %v\n", err)
 		s.mu.Unlock()
 	} else {
 		data, err := jsonrpc2.EncodeMessage(msg)
@@ -250,7 +254,7 @@ func (s *loggingConn) Write(ctx context.Context, msg jsonrpc.Message) error {
 	err := s.delegate.Write(ctx, msg)
 	if err != nil {
 		s.mu.Lock()
-		fmt.Fprintf(s.w, "write error: %v", err)
+		fmt.Fprintf(s.w, "write error: %v\n", err)
 		s.mu.Unlock()
 	} else {
 		data, err := jsonrpc2.EncodeMessage(msg)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -115,7 +115,7 @@ github.com/lestrrat-go/option/v2
 ## explicit; go 1.12
 github.com/mailru/easyjson/buffer
 github.com/mailru/easyjson/jwriter
-# github.com/modelcontextprotocol/go-sdk v0.8.0
+# github.com/modelcontextprotocol/go-sdk v1.0.0
 ## explicit; go 1.23.0
 github.com/modelcontextprotocol/go-sdk/auth
 github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2


### PR DESCRIPTION
The awaited 1.0.0 sdk is here: 
https://github.com/modelcontextprotocol/go-sdk/releases/tag/v1.0.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded a core SDK dependency to its 1.0 stable release.
  * Improves stability, API consistency, and alignment with semantic versioning guarantees.
  * Enhances compatibility with current tooling and ecosystem updates.
  * No configuration or workflow changes required; behavior remains unchanged for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->