### PR TITLE
Fix port to :8080 from w/in the container

### DIFF
--- a/hack/lib/keycloak.sh
+++ b/hack/lib/keycloak.sh
@@ -338,7 +338,7 @@ function disable_trusted_hosts() {
   # Configure admin CLI credentials
   $CONTAINER_ENGINE exec "${KEYCLOAK_CONTAINER_NAME}" \
     /opt/keycloak/bin/kcadm.sh config credentials \
-    --server http://localhost:8081 \
+    --server http://localhost:8080 \
     --realm "${realm_name}" \
     --user "${KEYCLOAK_ADMIN}" \
     --password "${KEYCLOAK_ADMIN_PASSWORD}"


### PR DESCRIPTION
as per title

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Keycloak admin CLI configuration to target the correct default server port, preventing connection failures during the “disable trusted hosts” step. This improves reliability for local and development environments and ensures smoother setup and maintenance workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->