### PR TITLE
Add support for resource and resourceTemplate primitives from MCP spec

### DIFF
--- a/examples/http-conversion/README.md
+++ b/examples/http-conversion/README.md
@@ -25,6 +25,7 @@ The API will be available at `http://localhost:9090` with endpoints:
 - `DELETE /features/{id}` - Delete a feature request
 - `GET /openapi.json` - Get OpenAPI specification
 - `POST /prompts/feature-analysis` - Generate feature analysis prompt
+- `GET  /features/progress-report` - Get feature progress report (static resource)
 
 ### 2. Generate Initial MCP Configuration
 

--- a/examples/http-conversion/feature-requests/main.go
+++ b/examples/http-conversion/feature-requests/main.go
@@ -536,5 +536,8 @@ func getFeatureProgressReport(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "text/markdown")
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(report.String()))
+	if _, err := w.Write([]byte(report.String())); err != nil {
+		http.Error(w, "Failed to write response", http.StatusInternalServerError)
+		return
+	}
 }

--- a/examples/http-conversion/feature-requests/mcpfile-localhost.yaml
+++ b/examples/http-conversion/feature-requests/mcpfile-localhost.yaml
@@ -85,4 +85,14 @@ prompts:
     http:
       method: POST
       url: http://localhost:9090/prompts/feature-analysis
+resources:
+- name: "feature-progress-report"
+  title: "Feature Progress Report"
+  description: "Complete feature request progress report in markdown format"
+  uri: http://localhost:9090/features/progress-report
+  mimeType: "text/markdown"
+  invocation:
+    http:
+      method: GET
+      url: http://localhost:9090/features/progress-report
 version: 0.0.1

--- a/examples/http-conversion/feature-requests/mcpfile.yaml
+++ b/examples/http-conversion/feature-requests/mcpfile.yaml
@@ -85,4 +85,14 @@ prompts:
     http:
       method: POST
       url: http://feature-request-demo-default.apps.rosa.ozsht-2wqkz-4rk.36d8.p3.openshiftapps.com/prompts/feature-analysis
+resources:
+- name: "feature-progress-report"
+  title: "Feature Progress Report"
+  description: "Complete feature request progress report in markdown format"
+  uri: http://feature-request-demo-default.apps.rosa.ozsht-2wqkz-4rk.36d8.p3.openshiftapps.com/features/progress-report
+  invocation:
+    http:
+      method: GET
+      url: http://feature-request-demo-default.apps.rosa.ozsht-2wqkz-4rk.36d8.p3.openshiftapps.com/features/progress-report
+  mimeType: "text/markdown"
 version: 0.0.1

--- a/pkg/invocation/cli/cli_invocation.go
+++ b/pkg/invocation/cli/cli_invocation.go
@@ -174,15 +174,8 @@ func (ci *CliInvoker) InvokeResourceTemplate(ctx context.Context, req *mcp.ReadR
 		extraArgs:       make(map[string]any),
 	}
 
-	// Parse URI template and extract arguments from the incoming URI
-	if ci.URITemplate == "" {
-		return utils.McpResourceTextError("URI template not configured"), fmt.Errorf("URI template not configured")
-	}
-
-	uriTmpl, err := uritemplate.New(ci.URITemplate)
-	if err != nil {
-		return utils.McpResourceTextError("invalid URI template: %s", err.Error()), err
-	}
+	//  URI template syntax is validated during parsing, so we can safely use it here
+	uriTmpl, _ := uritemplate.New(ci.URITemplate)
 
 	// Match the incoming URI against the template to extract argument values
 	matches := uriTmpl.Match(req.Params.URI)

--- a/pkg/invocation/cli/cli_invocation.go
+++ b/pkg/invocation/cli/cli_invocation.go
@@ -221,8 +221,9 @@ func (ci *CliInvoker) InvokeResourceTemplate(ctx context.Context, req *mcp.ReadR
 	return &mcp.ReadResourceResult{
 		Contents: []*mcp.ResourceContents{
 			{
-				URI:  req.Params.URI,
-				Text: string(output),
+				URI:      req.Params.URI,
+				MIMEType: "text/plain",
+				Text:     string(output),
 			},
 		},
 	}, nil

--- a/pkg/invocation/cli/cli_invocation.go
+++ b/pkg/invocation/cli/cli_invocation.go
@@ -10,6 +10,7 @@ import (
 	"github.com/genmcp/gen-mcp/pkg/invocation/utils"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/yosida95/uritemplate/v3"
 )
 
 type Formatter interface {
@@ -21,6 +22,7 @@ type CliInvoker struct {
 	ArgumentIndices    map[string]int       // map to where each argument should go in the command
 	ArgumentFormatters map[string]Formatter // map to the functions to format each variable
 	InputSchema        *jsonschema.Resolved // InputSchema for the tool
+	URITemplate        string               // MCP URI template (for resource templates only)
 }
 
 var _ invocation.Invoker = &CliInvoker{}
@@ -139,6 +141,88 @@ func (ci *CliInvoker) InvokePrompt(ctx context.Context, req *mcp.GetPromptReques
 			{
 				Role:    "assistant",
 				Content: &mcp.TextContent{Text: string(output)},
+			},
+		},
+	}, nil
+}
+
+func (ci *CliInvoker) InvokeResource(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	cmd := exec.Command("bash", "-c", ci.CommandTemplate)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return utils.McpResourceTextError("encountered error while calling command: %s. output was: %s.", err.Error(), string(output)), err
+	}
+
+	return &mcp.ReadResourceResult{
+		Contents: []*mcp.ResourceContents{
+			{
+				URI:      req.Params.URI,
+				MIMEType: "text/plain",
+				Text:     string(output),
+			},
+		},
+	}, nil
+}
+
+func (ci *CliInvoker) InvokeResourceTemplate(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	cb := &commandBuilder{
+		commandTemplate: ci.CommandTemplate,
+		argIndices:      ci.ArgumentIndices,
+		argFormatters:   ci.ArgumentFormatters,
+		argValues:       make([]any, len(ci.ArgumentIndices)),
+		extraArgs:       make(map[string]any),
+	}
+
+	// Parse URI template and extract arguments from the incoming URI
+	if ci.URITemplate == "" {
+		return utils.McpResourceTextError("URI template not configured"), fmt.Errorf("URI template not configured")
+	}
+
+	uriTmpl, err := uritemplate.New(ci.URITemplate)
+	if err != nil {
+		return utils.McpResourceTextError("invalid URI template: %s", err.Error()), err
+	}
+
+	// Match the incoming URI against the template to extract argument values
+	matches := uriTmpl.Match(req.Params.URI)
+	if matches == nil {
+		return utils.McpResourceTextError("URI does not match template"), fmt.Errorf("URI '%s' does not match template '%s'", req.Params.URI, ci.URITemplate)
+	}
+
+	// Extract arguments and populate command builder
+	argsMap := make(map[string]any)
+	for _, paramName := range uriTmpl.Varnames() {
+		if val := matches.Get(paramName); val.Valid() {
+			argValue := val.String()
+			cb.SetField(paramName, argValue)
+			argsMap[paramName] = argValue
+		} else {
+			return utils.McpResourceTextError("missing required parameter: %s", paramName), fmt.Errorf("missing required parameter: %s", paramName)
+		}
+	}
+
+	if err := ci.InputSchema.Validate(argsMap); err != nil {
+		return utils.McpResourceTextError("failed to validate resource template request: %s", err.Error()), err
+	}
+
+	command, err := cb.GetResult()
+	if err != nil {
+		return utils.McpResourceTextError("failed to build command: %s", err.Error()), err
+	}
+
+	cmd := exec.Command("bash", "-c", command.(string))
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return utils.McpResourceTextError("encountered error while calling command: %s. output was: %s.", err.Error(), string(output)), err
+	}
+
+	return &mcp.ReadResourceResult{
+		Contents: []*mcp.ResourceContents{
+			{
+				URI:  req.Params.URI,
+				Text: string(output),
 			},
 		},
 	}, nil

--- a/pkg/invocation/cli/cli_invocation_test.go
+++ b/pkg/invocation/cli/cli_invocation_test.go
@@ -609,25 +609,6 @@ func TestCliResourceTemplateInvocation(t *testing.T) {
 			errorMsg:    "does not match template",
 		},
 		{
-			name: "resource template with empty URI template",
-			cliInvoker: CliInvoker{
-				CommandTemplate: "echo 'Data'",
-				ArgumentIndices: make(map[string]int),
-				ArgumentFormatters: map[string]Formatter{
-					"city": stringFormatter{},
-				},
-				InputSchema: resolvedWithCityDate,
-				URITemplate: "",
-			},
-			request: &mcp.ReadResourceRequest{
-				Params: &mcp.ReadResourceParams{
-					URI: "app://data",
-				},
-			},
-			expectError: true,
-			errorMsg:    "URI template not configured",
-		},
-		{
 			name: "resource template with command failure",
 			cliInvoker: CliInvoker{
 				CommandTemplate: "nonexistentcmdforresource456 %s",

--- a/pkg/invocation/cli/config.go
+++ b/pkg/invocation/cli/config.go
@@ -11,6 +11,7 @@ type CliInvocationConfig struct {
 	Command           string                       `json:"command"`
 	TemplateVariables map[string]*TemplateVariable `json:"templateVariables,omitempty"`
 	ParameterIndices  map[string]int               `json:"-"`
+	URITemplate       string                       `json:"-"` // MCP URI template (for resource templates only)
 }
 
 var _ invocation.InvocationConfig = &CliInvocationConfig{}

--- a/pkg/invocation/cli/factory.go
+++ b/pkg/invocation/cli/factory.go
@@ -38,6 +38,7 @@ func (f *InvokerFactory) CreateInvoker(config invocation.InvocationConfig, schem
 		ArgumentIndices:    cic.ParameterIndices,
 		ArgumentFormatters: formatters,
 		InputSchema:        schema,
+		URITemplate:        cic.URITemplate,
 	}, nil
 
 }

--- a/pkg/invocation/cli/parser.go
+++ b/pkg/invocation/cli/parser.go
@@ -25,6 +25,24 @@ func (p *Parser) ParsePrompt(data json.RawMessage, prompt *mcpfile.Prompt) (invo
 	return p.parsePrimitive(data, primitiveAdapter{InputSchema: prompt.InputSchema})
 }
 
+func (p *Parser) ParseResource(data json.RawMessage, resource *mcpfile.Resource) (invocation.InvocationConfig, error) {
+	return p.parsePrimitive(data, primitiveAdapter{InputSchema: resource.InputSchema})
+}
+
+func (p *Parser) ParseResourceTemplate(data json.RawMessage, resourceTemplate *mcpfile.ResourceTemplate) (invocation.InvocationConfig, error) {
+	config, err := p.parsePrimitive(data, primitiveAdapter{InputSchema: resourceTemplate.InputSchema})
+	if err != nil {
+		return nil, err
+	}
+
+	// Set the URI template for resource templates
+	if cic, ok := config.(*CliInvocationConfig); ok {
+		cic.URITemplate = resourceTemplate.URITemplate
+	}
+
+	return config, nil
+}
+
 func (p *Parser) parsePrimitive(data json.RawMessage, primitive primitiveAdapter) (invocation.InvocationConfig, error) {
 	type Doppleganger CliInvocationConfig
 

--- a/pkg/invocation/cli/parser.go
+++ b/pkg/invocation/cli/parser.go
@@ -9,6 +9,7 @@ import (
 	"github.com/genmcp/gen-mcp/pkg/invocation/utils"
 	"github.com/genmcp/gen-mcp/pkg/mcpfile"
 	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/yosida95/uritemplate/v3"
 )
 
 type Parser struct{}
@@ -26,13 +27,31 @@ func (p *Parser) ParsePrompt(data json.RawMessage, prompt *mcpfile.Prompt) (invo
 }
 
 func (p *Parser) ParseResource(data json.RawMessage, resource *mcpfile.Resource) (invocation.InvocationConfig, error) {
-	return p.parsePrimitive(data, primitiveAdapter{InputSchema: resource.InputSchema})
+	config, err := p.parsePrimitive(data, primitiveAdapter{InputSchema: resource.InputSchema})
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate that static resources don't have template variables that would never be filled
+	if cic, ok := config.(*CliInvocationConfig); ok {
+		if len(cic.ParameterIndices) > 0 {
+			return nil, fmt.Errorf("static resource command cannot contain template variables")
+		}
+	}
+
+	return config, nil
 }
 
 func (p *Parser) ParseResourceTemplate(data json.RawMessage, resourceTemplate *mcpfile.ResourceTemplate) (invocation.InvocationConfig, error) {
 	config, err := p.parsePrimitive(data, primitiveAdapter{InputSchema: resourceTemplate.InputSchema})
 	if err != nil {
 		return nil, err
+	}
+
+	// Validate URI template syntax early during parsing
+	_, err = uritemplate.New(resourceTemplate.URITemplate)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URI template '%s': %w", resourceTemplate.URITemplate, err)
 	}
 
 	// Set the URI template for resource templates

--- a/pkg/invocation/factory.go
+++ b/pkg/invocation/factory.go
@@ -41,3 +41,39 @@ func CreatePromptInvoker(prompt *mcpfile.Prompt) (Invoker, error) {
 
 	return factory.CreateInvoker(config, prompt.ResolvedInputSchema)
 }
+
+func CreateResourceInvoker(resource *mcpfile.Resource) (Invoker, error) {
+	config, err := ParseResourceInvocation(resource.InvocationType, resource.InvocationData, resource)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	factory, exists := globalRegistry.factories[resource.InvocationType]
+	if !exists {
+		return nil, fmt.Errorf("no invoker factory for type: '%s'", resource.InvocationType)
+	}
+
+	return factory.CreateInvoker(config, resource.ResolvedInputSchema)
+}
+
+func CreateResourceTemplateInvoker(resourceTemplate *mcpfile.ResourceTemplate) (Invoker, error) {
+	config, err := ParseResourceTemplateInvocation(resourceTemplate.InvocationType, resourceTemplate.InvocationData, resourceTemplate)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	factory, exists := globalRegistry.factories[resourceTemplate.InvocationType]
+	if !exists {
+		return nil, fmt.Errorf("no invoker factory for type: '%s'", resourceTemplate.InvocationType)
+	}
+
+	return factory.CreateInvoker(config, resourceTemplate.ResolvedInputSchema)
+}

--- a/pkg/invocation/http/config.go
+++ b/pkg/invocation/http/config.go
@@ -22,6 +22,7 @@ type HttpInvocationConfig struct {
 	PathTemplate string         `json:"url"`
 	PathIndices  map[string]int `json:"-"`
 	Method       string         `json:"method"`
+	URITemplate  string         `json:"-"` // MCP URI template (for resource templates only)
 }
 
 var _ invocation.InvocationConfig = &HttpInvocationConfig{}

--- a/pkg/invocation/http/factory.go
+++ b/pkg/invocation/http/factory.go
@@ -20,6 +20,7 @@ func (f *InvokerFactory) CreateInvoker(config invocation.InvocationConfig, schem
 		PathIndeces:  hic.PathIndices,
 		Method:       hic.Method,
 		InputSchema:  schema,
+		URITemplate:  hic.URITemplate,
 	}
 
 	return invoker, nil

--- a/pkg/invocation/http/parser.go
+++ b/pkg/invocation/http/parser.go
@@ -27,6 +27,24 @@ func (p *Parser) ParsePrompt(data json.RawMessage, prompt *mcpfile.Prompt) (invo
 	return p.parsePrimitive(data, primitiveAdapter{InputSchema: prompt.InputSchema})
 }
 
+func (p *Parser) ParseResource(data json.RawMessage, resource *mcpfile.Resource) (invocation.InvocationConfig, error) {
+	return p.parsePrimitive(data, primitiveAdapter{InputSchema: resource.InputSchema})
+}
+
+func (p *Parser) ParseResourceTemplate(data json.RawMessage, resourceTemplate *mcpfile.ResourceTemplate) (invocation.InvocationConfig, error) {
+	config, err := p.parsePrimitive(data, primitiveAdapter{InputSchema: resourceTemplate.InputSchema})
+	if err != nil {
+		return nil, err
+	}
+
+	// Set the URI template for resource templates
+	if hic, ok := config.(*HttpInvocationConfig); ok {
+		hic.URITemplate = resourceTemplate.URITemplate
+	}
+
+	return config, nil
+}
+
 func (p *Parser) parsePrimitive(data json.RawMessage, primitive primitiveAdapter) (invocation.InvocationConfig, error) {
 	type Doppleganger HttpInvocationConfig
 

--- a/pkg/invocation/http/parser.go
+++ b/pkg/invocation/http/parser.go
@@ -9,6 +9,7 @@ import (
 	"github.com/genmcp/gen-mcp/pkg/invocation/utils"
 	"github.com/genmcp/gen-mcp/pkg/mcpfile"
 	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/yosida95/uritemplate/v3"
 )
 
 type Parser struct{}
@@ -28,13 +29,31 @@ func (p *Parser) ParsePrompt(data json.RawMessage, prompt *mcpfile.Prompt) (invo
 }
 
 func (p *Parser) ParseResource(data json.RawMessage, resource *mcpfile.Resource) (invocation.InvocationConfig, error) {
-	return p.parsePrimitive(data, primitiveAdapter{InputSchema: resource.InputSchema})
+	config, err := p.parsePrimitive(data, primitiveAdapter{InputSchema: resource.InputSchema})
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate that static resources don't have path parameters that would never be filled
+	if hic, ok := config.(*HttpInvocationConfig); ok {
+		if len(hic.PathIndices) > 0 {
+			return nil, fmt.Errorf("static resource URL cannot contain path parameters")
+		}
+	}
+
+	return config, nil
 }
 
 func (p *Parser) ParseResourceTemplate(data json.RawMessage, resourceTemplate *mcpfile.ResourceTemplate) (invocation.InvocationConfig, error) {
 	config, err := p.parsePrimitive(data, primitiveAdapter{InputSchema: resourceTemplate.InputSchema})
 	if err != nil {
 		return nil, err
+	}
+
+	// Validate URI template syntax early during parsing
+	_, err = uritemplate.New(resourceTemplate.URITemplate)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URI template '%s': %w", resourceTemplate.URITemplate, err)
 	}
 
 	// Set the URI template for resource templates

--- a/pkg/invocation/http/parser_test.go
+++ b/pkg/invocation/http/parser_test.go
@@ -85,3 +85,65 @@ func TestParser_Parse(t *testing.T) {
 		})
 	}
 }
+
+func TestParser_ParseResource(t *testing.T) {
+	tt := []struct {
+		name           string
+		inputData      json.RawMessage
+		resource       *mcpfile.Resource
+		expectedConfig *HttpInvocationConfig
+		expectError    bool
+		errorContains  string
+	}{
+		{
+			name:      "valid static resource without path parameters",
+			inputData: json.RawMessage(`{"url": "http://localhost:8080/status", "method": "get"}`),
+			resource: &mcpfile.Resource{
+				InputSchema: &jsonschema.Schema{
+					Type: invocation.JsonSchemaTypeObject,
+				},
+			},
+			expectedConfig: &HttpInvocationConfig{
+				PathTemplate: "http://localhost:8080/status",
+				PathIndices:  map[string]int{},
+				Method:       "GET",
+			},
+			expectError: false,
+		},
+		{
+			name:      "invalid static resource with path parameters",
+			inputData: json.RawMessage(`{"url": "http://localhost:8080/users/{id}", "method": "get"}`),
+			resource: &mcpfile.Resource{
+				InputSchema: &jsonschema.Schema{
+					Type: invocation.JsonSchemaTypeObject,
+					Properties: map[string]*jsonschema.Schema{
+						"id": {Type: invocation.JsonSchemaTypeInteger},
+					},
+				},
+			},
+			expectedConfig: nil,
+			expectError:    true,
+			errorContains:  "static resource URL cannot contain path parameters",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			parser := &Parser{}
+			config, err := parser.ParseResource(tc.inputData, tc.resource)
+
+			if tc.expectError {
+				assert.Error(t, err, "parser should return an error")
+				assert.Nil(t, config, "config should be nil on error")
+				if tc.errorContains != "" {
+					assert.Contains(t, err.Error(), tc.errorContains, "error message should contain expected text")
+				}
+			} else {
+				assert.NoError(t, err, "parser should not return an error")
+				assert.Equal(t, tc.expectedConfig, config, "parsed config should match expected")
+			}
+		})
+	}
+}

--- a/pkg/invocation/register.go
+++ b/pkg/invocation/register.go
@@ -43,6 +43,24 @@ func ParsePromptInvocation(invocationType string, data json.RawMessage, prompt *
 	return parser.ParsePrompt(data, prompt)
 }
 
+func ParseResourceInvocation(invocationType string, data json.RawMessage, resource *mcpfile.Resource) (InvocationConfig, error) {
+	parser, exists := globalRegistry.parsers[invocationType]
+	if !exists {
+		return nil, fmt.Errorf("unknown invocation type: '%s'", invocationType)
+	}
+
+	return parser.ParseResource(data, resource)
+}
+
+func ParseResourceTemplateInvocation(invocationType string, data json.RawMessage, resourceTemplate *mcpfile.ResourceTemplate) (InvocationConfig, error) {
+	parser, exists := globalRegistry.parsers[invocationType]
+	if !exists {
+		return nil, fmt.Errorf("unknown invocation type: '%s'", invocationType)
+	}
+
+	return parser.ParseResourceTemplate(data, resourceTemplate)
+}
+
 func InvocationValidator(invocationType string, data json.RawMessage, primitive mcpfile.Primitive) error {
 	switch p := primitive.(type) {
 	case *mcpfile.Tool:

--- a/pkg/invocation/register.go
+++ b/pkg/invocation/register.go
@@ -74,7 +74,18 @@ func InvocationValidator(invocationType string, data json.RawMessage, primitive 
 		if err != nil {
 			return fmt.Errorf("failed to parse invocation: %w", err)
 		}
-
+		return config.Validate()
+	case *mcpfile.Resource:
+		config, err := ParseResourceInvocation(invocationType, data, p)
+		if err != nil {
+			return fmt.Errorf("failed to parse invocation: %w", err)
+		}
+		return config.Validate()
+	case *mcpfile.ResourceTemplate:
+		config, err := ParseResourceTemplateInvocation(invocationType, data, p)
+		if err != nil {
+			return fmt.Errorf("failed to parse invocation: %w", err)
+		}
 		return config.Validate()
 	default:
 		return fmt.Errorf("unsupported primitive type %T", primitive)

--- a/pkg/invocation/types.go
+++ b/pkg/invocation/types.go
@@ -22,6 +22,8 @@ const (
 type Invoker interface {
 	Invoke(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error)
 	InvokePrompt(ctx context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error)
+	InvokeResource(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error)
+	InvokeResourceTemplate(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error)
 }
 
 type InvocationConfig interface {
@@ -31,6 +33,8 @@ type InvocationConfig interface {
 type InvocationConfigParser interface {
 	Parse(data json.RawMessage, tool *mcpfile.Tool) (InvocationConfig, error)
 	ParsePrompt(data json.RawMessage, prompt *mcpfile.Prompt) (InvocationConfig, error)
+	ParseResource(data json.RawMessage, resource *mcpfile.Resource) (InvocationConfig, error)
+	ParseResourceTemplate(data json.RawMessage, resourceTemplate *mcpfile.ResourceTemplate) (InvocationConfig, error)
 }
 
 type InvokerFactory interface {

--- a/pkg/invocation/utils/error_response.go
+++ b/pkg/invocation/utils/error_response.go
@@ -26,3 +26,11 @@ func McpPromptTextError(format string, args ...any) *mcp.GetPromptResult {
 		},
 	}
 }
+
+func McpResourceTextError(format string, args ...any) *mcp.ReadResourceResult {
+	return &mcp.ReadResourceResult{
+		Contents: []*mcp.ResourceContents{
+			{Text: fmt.Sprintf(format, args...)},
+		},
+	}
+}

--- a/pkg/mcpfile/parser.go
+++ b/pkg/mcpfile/parser.go
@@ -173,6 +173,70 @@ func (p *Prompt) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (p *Resource) UnmarshalJSON(data []byte) error {
+	type Doppleganger Resource
+
+	tmp := struct {
+		Invocation map[string]json.RawMessage `json:"invocation"`
+		*Doppleganger
+	}{
+		Doppleganger: (*Doppleganger)(p),
+	}
+
+	err := json.Unmarshal(data, &tmp)
+	if err != nil {
+		return err
+	}
+
+	if p.InputSchema != nil && p.InputSchema.Properties == nil {
+		// set the properties to be not nil so that it serializes as {} (required for some clients to properly parse the tool)
+		p.InputSchema.Properties = make(map[string]*jsonschema.Schema)
+	}
+
+	if len(tmp.Invocation) != 1 {
+		return fmt.Errorf("only one invocation handler should be defined per prompt")
+	}
+
+	for k, v := range tmp.Invocation {
+		p.InvocationType = strings.ToLower(k)
+		p.InvocationData = v
+	}
+
+	return nil
+}
+
+func (p *ResourceTemplate) UnmarshalJSON(data []byte) error {
+	type Doppleganger ResourceTemplate
+
+	tmp := struct {
+		Invocation map[string]json.RawMessage `json:"invocation"`
+		*Doppleganger
+	}{
+		Doppleganger: (*Doppleganger)(p),
+	}
+
+	err := json.Unmarshal(data, &tmp)
+	if err != nil {
+		return err
+	}
+
+	if p.InputSchema != nil && p.InputSchema.Properties == nil {
+		// set the properties to be not nil so that it serializes as {} (required for some clients to properly parse the tool)
+		p.InputSchema.Properties = make(map[string]*jsonschema.Schema)
+	}
+
+	if len(tmp.Invocation) != 1 {
+		return fmt.Errorf("only one invocation handler should be defined per prompt")
+	}
+
+	for k, v := range tmp.Invocation {
+		p.InvocationType = strings.ToLower(k)
+		p.InvocationData = v
+	}
+
+	return nil
+}
+
 func (s *StreamableHTTPConfig) UnmarshalJSON(data []byte) error {
 	type Doppleganger StreamableHTTPConfig
 

--- a/pkg/mcpfile/parser.go
+++ b/pkg/mcpfile/parser.go
@@ -194,7 +194,7 @@ func (p *Resource) UnmarshalJSON(data []byte) error {
 	}
 
 	if len(tmp.Invocation) != 1 {
-		return fmt.Errorf("only one invocation handler should be defined per prompt")
+		return fmt.Errorf("only one invocation handler should be defined per resource")
 	}
 
 	for k, v := range tmp.Invocation {
@@ -226,7 +226,7 @@ func (p *ResourceTemplate) UnmarshalJSON(data []byte) error {
 	}
 
 	if len(tmp.Invocation) != 1 {
-		return fmt.Errorf("only one invocation handler should be defined per prompt")
+		return fmt.Errorf("only one invocation handler should be defined per resource template")
 	}
 
 	for k, v := range tmp.Invocation {

--- a/pkg/mcpfile/parser_test.go
+++ b/pkg/mcpfile/parser_test.go
@@ -287,6 +287,78 @@ func TestParseMcpFile(t *testing.T) {
 					},
 				},
 			},
+		}, "one server, resources": {
+			testFileName: "one-server-resources.yaml",
+			expected: &MCPFile{
+				FileVersion: MCPFileVersion,
+				MCPServer: MCPServer{
+					Name:    "test-server",
+					Version: "1.0.0",
+					Runtime: &ServerRuntime{
+						TransportProtocol: TransportProtocolStreamableHttp,
+						StreamableHTTPConfig: &StreamableHTTPConfig{
+							BasePath:  DefaultBasePath,
+							Port:      3000,
+							Stateless: true,
+						},
+					},
+					Resources: []*Resource{
+						{
+							Name:           "web_server_access_log",
+							Title:          "Web Server Access Log",
+							Description:    "Contains a record of all requests made to the web server",
+							MIMEType:       "text/plain",
+							Size:           1024,
+							URI:            "http://localhost:5000/access.log",
+							InvocationData: json.RawMessage(`{"method":"GET","url":"http://localhost:5000"}`),
+							InvocationType: "http",
+						},
+					},
+				},
+			},
+		},
+		"one server, resource templates": {
+			testFileName: "one-server-resource-templates.yaml",
+			expected: &MCPFile{
+				FileVersion: MCPFileVersion,
+				MCPServer: MCPServer{
+					Name:    "test-server",
+					Version: "1.0.0",
+					Runtime: &ServerRuntime{
+						TransportProtocol: TransportProtocolStreamableHttp,
+						StreamableHTTPConfig: &StreamableHTTPConfig{
+							BasePath:  DefaultBasePath,
+							Port:      3000,
+							Stateless: true,
+						},
+					},
+					ResourceTemplates: []*ResourceTemplate{
+						{
+							Name:        "weather-forecast",
+							Title:       "Weather Forecast",
+							Description: "Get weather forecast for any city and date",
+							MIMEType:    "application/json",
+							URITemplate: "weather://forecast/{city}/{date}",
+							InputSchema: &jsonschema.Schema{
+								Type: "object",
+								Properties: map[string]*jsonschema.Schema{
+									"city": {
+										Type:        "string",
+										Description: "The city to get weather for",
+									},
+									"date": {
+										Type:        "string",
+										Description: "The date to get weather for",
+									},
+								},
+								Required: []string{"city", "date"},
+							},
+							InvocationData: json.RawMessage(`{"method":"GET","url":"http://localhost:5000/forecast"}`),
+							InvocationType: "http",
+						},
+					},
+				},
+			},
 		},
 		"full demo": {
 			testFileName: "full-demo.yaml",

--- a/pkg/mcpfile/testdata/one-server-resource-templates.yaml
+++ b/pkg/mcpfile/testdata/one-server-resource-templates.yaml
@@ -1,0 +1,25 @@
+mcpFileVersion: 0.1.0
+name: test-server
+version: 1.0.0
+resourceTemplates:
+- name: weather-forecast
+  title: "Weather Forecast"
+  description: "Get weather forecast for any city and date"
+  mimeType: "application/json"
+  uriTemplate: "weather://forecast/{city}/{date}"
+  inputSchema:
+    type: object
+    properties:
+      city:
+        type: string
+        description: "The city to get weather for"
+      date:
+        type: string
+        description: "The date to get weather for"
+    required:
+      - city
+      - date
+  invocation:
+    http:
+      url: http://localhost:5000/forecast
+      method: GET

--- a/pkg/mcpfile/testdata/one-server-resources.yaml
+++ b/pkg/mcpfile/testdata/one-server-resources.yaml
@@ -1,0 +1,15 @@
+mcpFileVersion: 0.1.0
+name: test-server
+version: 1.0.0
+resources:
+- name: web_server_access_log
+  title: "Web Server Access Log"
+  description: "Contains a record of all requests made to the web server"
+  mimeType: text/plain
+  size: 1024
+  uri: http://localhost:5000/access.log
+  invocation:
+    http:
+      url: http://localhost:5000
+      method: GET
+

--- a/pkg/mcpfile/types.go
+++ b/pkg/mcpfile/types.go
@@ -14,6 +14,8 @@ const (
 	TransportProtocolStdio          = "stdio"
 	PrimitiveTypeTool               = "tool"
 	PrimitiveTypePrompt             = "prompt"
+	PrimitiveTypeResource           = "resource"
+	PrimitiveTypeResourceTemplate   = "resourceTemplate"
 )
 
 type Primitive interface {
@@ -82,6 +84,57 @@ type PromptArgument struct {
 	Required    bool   `json:"required,omitempty"`
 }
 
+type Resource struct {
+	Name           string             `json:"name"`                     // name of the resource
+	Title          string             `json:"title,omitempty"`          // optional human readable name of the resource, for client display
+	Description    string             `json:"description"`              // description of the resource
+	MIMEType       string             `json:"mimeType,omitempty"`       // The MIME type of this resource, if known.
+	Size           int64              `json:"size,omitempty"`           // The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.
+	URI            string             `json:"uri"`                      // The URI of this resource.
+	InputSchema    *jsonschema.Schema `json:"inputSchema"`              // input schema to call the resource
+	OutputSchema   *jsonschema.Schema `json:"outputSchema,omitempty"`   // optional output schema of the resource
+	InvocationData json.RawMessage    `json:"invocation"`               // how the resource should be invoked
+	InvocationType string             `json:"-"`                        // which invocation type should be used
+	RequiredScopes []string           `json:"requiredScopes,omitempty"` // required OAuth scopes to be able to use the resource
+
+	ResolvedInputSchema *jsonschema.Resolved `json:"-"` // used internally after resolving the schema during validation
+}
+
+func (r Resource) GetName() string                              { return r.Name }
+func (r Resource) GetDescription() string                       { return r.Description }
+func (r Resource) PrimitiveType() string                        { return PrimitiveTypeResource }
+func (r Resource) GetInputSchema() *jsonschema.Schema           { return r.InputSchema }
+func (r Resource) GetOutputSchema() *jsonschema.Schema          { return r.OutputSchema }
+func (r Resource) GetInvocationData() json.RawMessage           { return r.InvocationData }
+func (r Resource) GetInvocationType() string                    { return r.InvocationType }
+func (r Resource) GetRequiredScopes() []string                  { return r.RequiredScopes }
+func (r Resource) GetResolvedInputSchema() *jsonschema.Resolved { return r.ResolvedInputSchema }
+
+type ResourceTemplate struct {
+	Name           string             `json:"name"`                     // name of the resource template
+	Title          string             `json:"title,omitempty"`          // optional human readable name of the resource template, for client display
+	Description    string             `json:"description"`              // description of the resource template
+	MIMEType       string             `json:"mimeType,omitempty"`       // The MIME type for all resources that match this template
+	URITemplate    string             `json:"uriTemplate"`              // A URI template (according to RFC 6570) that can be used to construct resource URI
+	InputSchema    *jsonschema.Schema `json:"inputSchema"`              // input schema to call the resource template
+	OutputSchema   *jsonschema.Schema `json:"outputSchema,omitempty"`   // optional output schema of the resource template
+	InvocationData json.RawMessage    `json:"invocation"`               // how the resource template should be invoked
+	InvocationType string             `json:"-"`                        // which invocation type should be used
+	RequiredScopes []string           `json:"requiredScopes,omitempty"` // required OAuth scopes to be able to use the resource template
+
+	ResolvedInputSchema *jsonschema.Resolved `json:"-"` // used internally after resolving the schema during validation
+}
+
+func (r ResourceTemplate) GetName() string                              { return r.Name }
+func (r ResourceTemplate) GetDescription() string                       { return r.Description }
+func (r ResourceTemplate) PrimitiveType() string                        { return PrimitiveTypeResourceTemplate }
+func (r ResourceTemplate) GetInputSchema() *jsonschema.Schema           { return r.InputSchema }
+func (r ResourceTemplate) GetOutputSchema() *jsonschema.Schema          { return r.OutputSchema }
+func (r ResourceTemplate) GetInvocationData() json.RawMessage           { return r.InvocationData }
+func (r ResourceTemplate) GetInvocationType() string                    { return r.InvocationType }
+func (r ResourceTemplate) GetRequiredScopes() []string                  { return r.RequiredScopes }
+func (r ResourceTemplate) GetResolvedInputSchema() *jsonschema.Resolved { return r.ResolvedInputSchema }
+
 type StreamableHTTPConfig struct {
 	Port      int         `json:"port"`           // the port to start listening on
 	BasePath  string      `json:"basePath"`       // the base path for the MCP server
@@ -110,11 +163,13 @@ type ServerRuntime struct {
 }
 
 type MCPServer struct {
-	Name    string         `json:"name"`              // name of the server
-	Version string         `json:"version"`           // version of the server
-	Runtime *ServerRuntime `json:"runtime,omitempty"` // runtime settings for the server
-	Tools   []*Tool        `json:"tools,omitempty"`   // set of tools available to the server
-	Prompts []*Prompt      `json:"prompts,omitempty"` // set of prompts available to the server
+	Name              string              `json:"name"`                        // name of the server
+	Version           string              `json:"version"`                     // version of the server
+	Runtime           *ServerRuntime      `json:"runtime,omitempty"`           // runtime settings for the server
+	Tools             []*Tool             `json:"tools,omitempty"`             // set of tools available to the server
+	Prompts           []*Prompt           `json:"prompts,omitempty"`           // set of prompts available to the server
+	Resources         []*Resource         `json:"resources,omitempty"`         // set of resources available to the server
+	ResourceTemplates []*ResourceTemplate `json:"resourceTemplates,omitempty"` // set of resource templates available to the server
 }
 
 type MCPFile struct {

--- a/pkg/mcpfile/validation.go
+++ b/pkg/mcpfile/validation.go
@@ -108,6 +108,9 @@ func (r *Resource) Validate(invocationValidator InvocationValidator) error {
 	if r.URI == "" {
 		err = errors.Join(err, fmt.Errorf("invalid resource: uri is required"))
 	}
+	if r.InputSchema != nil && strings.ToLower(r.InputSchema.Type) != "object" {
+		err = errors.Join(err, fmt.Errorf("invalid resource: inputScheme must be type object at the root"))
+	}
 	if r.InvocationData == nil {
 		err = errors.Join(err, fmt.Errorf("invalid resource: invocation is not set for the resource"))
 	} else if invocationErr := invocationValidator(r.InvocationType, r.InvocationData, r); invocationErr != nil {
@@ -126,6 +129,19 @@ func (rt *ResourceTemplate) Validate(invocationValidator InvocationValidator) er
 	}
 	if rt.URITemplate == "" {
 		err = errors.Join(err, fmt.Errorf("invalid resource template: uriTemplate is required"))
+	}
+	if rt.InputSchema == nil {
+		err = errors.Join(err, fmt.Errorf("invalid resource template: inputSchema is required"))
+	} else {
+		resolved, schemaErr := rt.InputSchema.Resolve(nil)
+		if schemaErr != nil {
+			err = errors.Join(err, fmt.Errorf("invalid resource template: inputSchema is not valid: %w", schemaErr))
+		} else {
+			rt.ResolvedInputSchema = resolved
+		}
+	}
+	if rt.InputSchema != nil && strings.ToLower(rt.InputSchema.Type) != "object" {
+		err = errors.Join(err, fmt.Errorf("invalid resource template: inputScheme must be type object at the root"))
 	}
 	if rt.InvocationData == nil {
 		err = errors.Join(err, fmt.Errorf("invalid resource template: invocation is not set for the resource template"))

--- a/pkg/mcpfile/validation.go
+++ b/pkg/mcpfile/validation.go
@@ -97,6 +97,44 @@ func (p *Prompt) Validate(invocationValidator InvocationValidator) error {
 	return err
 }
 
+func (r *Resource) Validate(invocationValidator InvocationValidator) error {
+	var err error = nil
+	if r.Name == "" {
+		err = errors.Join(err, fmt.Errorf("invalid resource: name is required"))
+	}
+	if r.Description == "" {
+		err = errors.Join(err, fmt.Errorf("invalid resource: description is required"))
+	}
+	if r.URI == "" {
+		err = errors.Join(err, fmt.Errorf("invalid resource: uri is required"))
+	}
+	if r.InvocationData == nil {
+		err = errors.Join(err, fmt.Errorf("invalid resource: invocation is not set for the resource"))
+	} else if invocationErr := invocationValidator(r.InvocationType, r.InvocationData, r); invocationErr != nil {
+		err = errors.Join(err, fmt.Errorf("invalid resource: invocation is not valid: %w", invocationErr))
+	}
+	return err
+}
+
+func (rt *ResourceTemplate) Validate(invocationValidator InvocationValidator) error {
+	var err error = nil
+	if rt.Name == "" {
+		err = errors.Join(err, fmt.Errorf("invalid resource template: name is required"))
+	}
+	if rt.Description == "" {
+		err = errors.Join(err, fmt.Errorf("invalid resource template: description is required"))
+	}
+	if rt.URITemplate == "" {
+		err = errors.Join(err, fmt.Errorf("invalid resource template: uriTemplate is required"))
+	}
+	if rt.InvocationData == nil {
+		err = errors.Join(err, fmt.Errorf("invalid resource template: invocation is not set for the resource template"))
+	} else if invocationErr := invocationValidator(rt.InvocationType, rt.InvocationData, rt); invocationErr != nil {
+		err = errors.Join(err, fmt.Errorf("invalid resource template: invocation is not valid: %w", invocationErr))
+	}
+	return err
+}
+
 func (s *MCPServer) Validate(invocationValidator InvocationValidator) error {
 	var err error = nil
 	if s.Name == "" {

--- a/pkg/mcpserver/server.go
+++ b/pkg/mcpserver/server.go
@@ -202,7 +202,7 @@ func createAuthorizedPromptHandler(prompt *mcpfile.Prompt) (mcp.PromptHandler, e
 func createAuthorizedResourceHandler(resource *mcpfile.Resource) (mcp.ResourceHandler, error) {
 	invoker, err := invocation.CreateResourceInvoker(resource)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create invoker for prompt %s: %w", resource.Name, err)
+		return nil, fmt.Errorf("failed to create invoker for resource %s: %w", resource.Name, err)
 	}
 
 	return func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
@@ -226,7 +226,7 @@ func createAuthorizedResourceTemplateHandler(resourceTemplate *mcpfile.ResourceT
 			return utils.McpResourceTextError("forbidden: %s for resource template '%s'", err.Error(), resourceTemplate.Name), fmt.Errorf("forbidden: %s for resource template '%s'", err.Error(), resourceTemplate.Name)
 		}
 
-		return invoker.InvokeResource(ctx, req)
+		return invoker.InvokeResourceTemplate(ctx, req)
 	}, nil
 }
 


### PR DESCRIPTION
Fixes: #7 

- add types and the necessary validation
- add http and cli invocation
- add example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GET /features/progress-report returns a Markdown feature progress report.
  * First-class Resources and Resource Templates with URI-template driven access and direct resource fetches (CLI & HTTP).
  * Server endpoints enforce required scopes for resource access.

* **Documentation**
  * API listing and resource metadata updated to include the Feature Progress Report.

* **Tests**
  * Added tests covering resource and resource-template invocation paths for CLI and HTTP.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->