### PR TITLE
Use the correct go version in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Transform any API into an MCP server in seconds, not hours
 
-[![Go Version](https://img.shields.io/badge/Go-1.21+-00ADD8?style=flat&logo=go)](https://golang.org/)
+![Go Version](https://img.shields.io/github/go-mod/go-version/genmcp/gen-mcp)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![MCP Compatible](https://img.shields.io/badge/MCP-Compatible-green.svg)](https://modelcontextprotocol.io/)
 


### PR DESCRIPTION
Using the correct go version from the go.mod in the README.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README’s Go version badge to dynamically reflect the module’s current version, improving accuracy and clarity for users reviewing project requirements.
  * Ensures the displayed Go compatibility remains up to date without manual edits.
  * No functional, runtime, or build behavior changes.
  * No action required for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->