### PR TITLE
fix: parsing returns error on invalid file version

### DIFF
--- a/pkg/mcpfile/parser.go
+++ b/pkg/mcpfile/parser.go
@@ -50,6 +50,10 @@ func (m *MCPFile) UnmarshalJSON(data []byte) error {
 		}
 	}
 
+	if m.FileVersion != MCPFileVersion {
+		return fmt.Errorf("invalid mcp file version %s, expected %s - please migrate your file and handle any breaking changes", m.FileVersion, MCPFileVersion)
+	}
+
 	// Unmarshal the rest into MCPServer
 	if err := json.Unmarshal(data, &m.MCPServer); err != nil {
 		return err

--- a/pkg/mcpfile/parser_test.go
+++ b/pkg/mcpfile/parser_test.go
@@ -11,9 +11,10 @@ import (
 
 func TestParseMcpFile(t *testing.T) {
 	tt := map[string]struct {
-		testFileName string
-		expected     *MCPFile
-		wantErr      bool
+		testFileName  string
+		expected      *MCPFile
+		wantErr       bool
+		errorContains string
 	}{
 		"no servers": {
 			testFileName: "no-servers.yaml",
@@ -490,6 +491,11 @@ func TestParseMcpFile(t *testing.T) {
 				},
 			},
 		},
+		"invalid version 0.0.1": {
+			testFileName:  "invalid-file-version.yaml",
+			wantErr:       true,
+			errorContains: "invalid mcp file version",
+		},
 	}
 
 	for testName, testCase := range tt {
@@ -498,6 +504,7 @@ func TestParseMcpFile(t *testing.T) {
 			mcpFile, err := ParseMCPFile(fmt.Sprintf("./testdata/%s", testCase.testFileName))
 			if testCase.wantErr {
 				assert.Error(t, err, "parsing mcp file should cause an error")
+				assert.ErrorContains(t, err, testCase.errorContains, "the error should contain the right message")
 			} else {
 				assert.NoError(t, err, "parsing mcp file should succeed")
 			}

--- a/pkg/mcpfile/testdata/invalid-file-version.yaml
+++ b/pkg/mcpfile/testdata/invalid-file-version.yaml
@@ -1,0 +1,20 @@
+mcpFileVersion: 0.0.1
+servers:
+- name: test-server
+  version: 1.0.0
+  tools:
+  - name: get_user_by_company
+    title: Users Provider
+    description: Get list of users from a given company
+    inputSchema:
+      type: object
+      properties:
+        companyName:
+          type: string
+          description: Name of the company
+      required:
+      - companyName
+    invocation:
+      http:
+        url: http://localhost:5000
+        method: POST


### PR DESCRIPTION
Resolves #158 

This PR validates that a given MCP file matches the expected version of genmcp.

IMO, since this is still an early stage project, simply erroring out and telling users to update their mcp file is valid for now

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MCP files with unsupported versions are now rejected early with a clear error, preventing parsing of incompatible configurations and improving reliability.

* **Tests**
  * Added a test case validating that an invalid file version produces the expected error message.
  * Enhanced test assertions to check for specific error content.
  * Introduced YAML test data representing an invalid file version scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->