### PR TITLE
Sign binaries built in CI with cosign

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -106,6 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write  # Permission for keyless signing
     strategy:
       matrix:
         goos: [linux, windows, darwin]
@@ -118,6 +119,9 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
 
       - name: Build genmcp CLI
         env:
@@ -152,13 +156,34 @@ jobs:
 
           zip "${SERVER_NAME}-${GOOS}-${GOARCH}.zip" "${OUTPUT_NAME}"
 
-      - name: Upload assets to release
+      - name: Sign CLI and Server ZIP files  # Step to sign artifacts
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          # Define file names
+          CLI_ZIP="genmcp-${GOOS}-${GOARCH}.zip"
+          SERVER_ZIP="genmcp-server-${GOOS}-${GOARCH}.zip"
+
+          echo "Signing ${CLI_ZIP}..."
+          # Sign the blob, outputting a signature and certificate
+          cosign sign-blob --yes "${CLI_ZIP}" \
+            --output-signature "${CLI_ZIP}.sig" \
+            --output-certificate "${CLI_ZIP}.pem"
+
+          echo "Signing ${SERVER_ZIP}..."
+          cosign sign-blob --yes "${SERVER_ZIP}" \
+            --output-signature "${SERVER_ZIP}.sig" \
+            --output-certificate "${SERVER_ZIP}.pem"
+
+      - name: Upload assets to release  # Upload all artifacts
         run: |
           VERSION="${{ needs.determine-version.outputs.prerelease_version }}"
           
-          # Upload assets
-          for file in *.zip; do
+          # Upload all zips, signatures (.sig), and certificates (.pem)
+          for file in *.zip *.sig *.pem; do
             if [ -f "$file" ]; then
+              echo "Uploading $file..."
               gh release upload "$VERSION" "$file" --clobber
             fi
           done

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -122,6 +122,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write  # Permission for keyless signing
     strategy:
       matrix:
         goos: [linux, windows, darwin]
@@ -134,6 +135,9 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
 
       - name: Build genmcp CLI
         env:
@@ -168,12 +172,32 @@ jobs:
 
           zip "${SERVER_NAME}-${GOOS}-${GOARCH}.zip" "${OUTPUT_NAME}"
 
-      - name: Upload assets to nightly release
+      - name: Sign CLI and Server ZIP files  # Step to sign artifacts
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          # Define file names
+          CLI_ZIP="genmcp-${GOOS}-${GOARCH}.zip"
+          SERVER_ZIP="genmcp-server-${GOOS}-${GOARCH}.zip"
+
+          echo "Signing ${CLI_ZIP}..."
+          # Sign the blob, outputting a signature and certificate
+          cosign sign-blob --yes "${CLI_ZIP}" \
+            --output-signature "${CLI_ZIP}.sig" \
+            --output-certificate "${CLI_ZIP}.pem"
+
+          echo "Signing ${SERVER_ZIP}..."
+          cosign sign-blob --yes "${SERVER_ZIP}" \
+            --output-signature "${SERVER_ZIP}.sig" \
+            --output-certificate "${SERVER_ZIP}.pem"
+
+      - name: Upload assets to nightly release  # Upload all artifacts
         run: |
           VERSION="${{ needs.check-and-create-nightly.outputs.nightly_version }}"
           
-          # Upload assets
-          for file in *.zip; do
+          # Upload all zips, signatures (.sig), and certificates (.pem)
+          for file in *.zip *.sig *.pem; do
             if [ -f "$file" ]; then
               gh release upload "$VERSION" "$file" --clobber
             fi

--- a/README.md
+++ b/README.md
@@ -41,6 +41,38 @@ chmod +x genmcp
 sudo mv genmcp /usr/local/bin
 ```
 
+#### Verify the signed binary
+
+You can cryptographically verify that the downloaded binaries (`.zip` files) are authentic and have not been tampered with. This process uses `cosign` to check the signature and certificate, which were generated securely during our automated build process.
+
+##### Step 1: Install Cosign
+
+You'll need the `cosign` command-line tool. Please see the [Official Cosign Installation Guide](https://docs.sigstore.dev/cosign/installation/).
+
+##### Step 2: Verify the Binary
+
+1.  From the release page, download three files for your platform:
+    * The binary archive (e.g., `genmcp-linux-amd64.zip`)
+    * The certificate (e.g., `genmcp-linux-amd64.zip.pem`)
+    * The signature (e.g., `genmcp-linux-amd64.zip.sig`)
+
+2.  Run the `cosign verify-blob` command in your terminal.
+
+    **Example (for the Linux amd64 CLI):**
+    ```bash
+      cosign verify-blob \
+         --certificate genmcp-linux-amd64.zip.pem \
+         --signature genmcp-linux-amd64.zip.sig \
+         --certificate-identity-regexp "https://github.com/genmcp/gen-mcp/.*" \
+         --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+         genmcp-linux-amd64.zip
+   ```
+
+3.  If the signature is valid, `cosign` will contact the public Sigstore transparency log and print:
+    ```
+    Verified OK
+    ```
+
 **Option B: Build from Source**
 ```bash
 # Clone and build

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -115,3 +115,35 @@ The **Nightly Release** workflow runs automatically at 02:00 UTC daily and:
 - **Nightly releases**: `nightly-YYYYMMDD-<commit>` (e.g., `nightly-20240315-abc123f`)
 
 The Z version (patch number) is automatically determined by checking existing releases for the X.Y version and incrementing accordingly.
+
+## Verify the signed binary
+
+You can cryptographically verify that the downloaded binaries (`.zip` files) are authentic and have not been tampered with. This process uses `cosign` to check the signature and certificate, which were generated securely during our automated build process.
+
+### Step 1: Install Cosign
+
+You'll need the `cosign` command-line tool. Please see the [Official Cosign Installation Guide](https://docs.sigstore.dev/cosign/installation/).
+
+### Step 2: Verify the Binary
+
+1.  From the release page, download three files for your platform:
+    * The binary archive (e.g., `genmcp-linux-amd64.zip`)
+    * The certificate (e.g., `genmcp-linux-amd64.zip.pem`)
+    * The signature (e.g., `genmcp-linux-amd64.zip.sig`)
+
+2.  Run the `cosign verify-blob` command in your terminal.
+
+    **Example (for the Linux amd64 CLI):**
+    ```bash
+      cosign verify-blob \
+         --certificate genmcp-linux-amd64.zip.pem \
+         --signature genmcp-linux-amd64.zip.sig \
+         --certificate-identity-regexp "https://github.com/genmcp/gen-mcp/.*" \
+         --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+         genmcp-linux-amd64.zip
+   ```
+
+3.  If the signature is valid, `cosign` will contact the public Sigstore transparency log and print:
+    ```
+    Verified OK
+    ```


### PR DESCRIPTION
Fixes #175 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release and nightly artifacts are now cryptographically signed (.sig and .pem files included) and uploaded alongside binaries; supports keyless signing for verification.

* **Documentation**
  * Added step-by-step “Verify the signed binary” instructions to README and release docs so users can validate downloaded binaries with cosign.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->