### PR TITLE
Fix JSON schema validation by handling google/jsonschema-go type incompatibility

### DIFF
--- a/pkg/mcpfile/types.go
+++ b/pkg/mcpfile/types.go
@@ -258,8 +258,8 @@ type StreamableHTTPConfig struct {
 	// Base path for the MCP server (default: /mcp).
 	BasePath string `json:"basePath,omitempty" jsonschema:"optional"`
 
-	// Indicates whether the server is stateless (default: true).
-	Stateless bool `json:"stateless" jsonschema:"optional"`
+	// Indicates whether the server is stateless (default: true when unset).
+	Stateless bool `json:"stateless,omitempty" jsonschema:"optional"`
 
 	// OAuth 2.0 configuration for protected resources.
 	Auth *AuthConfig `json:"auth,omitempty" jsonschema:"optional"`

--- a/specs/mcpfile-schema-0.1.0.json
+++ b/specs/mcpfile-schema-0.1.0.json
@@ -190,7 +190,9 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "mcpFileVersion"
+        "mcpFileVersion",
+        "name",
+        "version"
       ],
       "description": "MCPFile is the root structure of an MCP configuration file."
     },
@@ -445,7 +447,7 @@
         },
         "stateless": {
           "type": "boolean",
-          "description": "Indicates whether the server is stateless (default: true)."
+          "description": "Indicates whether the server is stateless (default: true when unset)."
         },
         "auth": {
           "$ref": "#/$defs/AuthConfig",

--- a/specs/mcpfile-schema.json
+++ b/specs/mcpfile-schema.json
@@ -190,7 +190,9 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "mcpFileVersion"
+        "mcpFileVersion",
+        "name",
+        "version"
       ],
       "description": "MCPFile is the root structure of an MCP configuration file."
     },
@@ -445,7 +447,7 @@
         },
         "stateless": {
           "type": "boolean",
-          "description": "Indicates whether the server is stateless (default: true)."
+          "description": "Indicates whether the server is stateless (default: true when unset)."
         },
         "auth": {
           "$ref": "#/$defs/AuthConfig",


### PR DESCRIPTION
Fixes: #169 

Changes:

 - Implement workaround using reflector.Mapper to treat google/jsonschema-go Schema as simple object type. 
 - Replace incorrect auto-detected required fields with explicit struct tag parsing via fixRequiredFields(). 
 - Correct optional fields (annotations, loggingConfig, stateless, Resource.inputSchema) that were wrongly required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Simplified MCPFile schema requirements—only mcpFileVersion is mandatory.
  * inputSchema/outputSchema are now explicit object types and inputSchema is optional for resources, prompts, and tools.
  * Server/stream settings (stateless, logging) are optional with sensible defaults; stream config requires only port.

* **Breaking Changes**
  * The previously shared "Schema" definition has been removed; consumers should use the explicit object schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->