### PR TITLE
add github templates for PRs and Issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,16 @@
+/kind bug
+
+## What version of gen-mcp?
+
+## Expected Behavior
+
+## Actual Behavior
+
+## Steps to Reproduce the Problem
+
+ - 
+ - 
+ -
+
+## Additional Info
+

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,9 @@
+/kind feature
+
+## Describe the feature
+[A clear and concise description of what you want to happen.]
+
+
+## Anything else you would like to add:
+[Miscellaneous information that will assist in solving the issue.]
+

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -1,0 +1,4 @@
+/kind other
+
+## Add your question or comment
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## What type of PR is this?
+
+<!--
+Add one of the following kinds:
+/kind feature
+/kind bug
+/kind cleanup
+/kind documentation
+/kind testing
+-->
+
+## What this PR does / why we need it:
+
+## Which issue(s) this PR fixes:
+
+Fixes #
+
+## Proposed Changes
+-
+-
+-
+
+## Release note:
+<!--  Write your release note if needed:
+Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
+-->
+```release-note
+
+```


### PR DESCRIPTION
I thought it would be nice to add some templates to the repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added standardized GitHub issue templates for bug reports, feature requests, and general inquiries
  * Added pull request template with predefined sections for metadata, description, affected issues, and release notes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->