### PR TITLE
feat: add evals example with gevals

### DIFF
--- a/examples/http-conversion/evals/README.md
+++ b/examples/http-conversion/evals/README.md
@@ -1,0 +1,108 @@
+# Evaluating MCP Servers with gevals
+
+This directory contains evaluation tests for our MCP server using [gevals](https://github.com/genmcp/gevals) - a tool that tests MCP servers by having AI agents complete real tasks.
+
+## What is gevals?
+
+gevals validates your MCP server by having an AI agent attempt to complete tasks using only the tools exposed by your server. It records all tool calls, analyzes the agent's behavior, and checks whether the tools are discoverable, clear, and correctly implemented.
+
+The workflow looks like this:
+```
+AI Agent → MCP Proxy (recording) → MCP Server
+```
+
+gevals records:
+- Which tools were called
+- What arguments were passed
+- When calls were made
+- Server responses
+
+## Files in this directory
+
+- **`eval.yaml`** - Main evaluation configuration that ties everything together
+- **`claude-code.yaml`** - Agent configuration (defines how to run the Claude Code agent)
+- **`mcp-config.yaml`** - MCP server connection details
+- **`mcpfile.yaml`** - The MCP server definition being evaluated
+- **`tasks/`** - Directory containing task definitions and expected outcomes
+
+## Running the evaluation
+
+1. Clone and build gevals (in the gevals repository directory):
+   ```bash
+   git clone https://github.com/genmcp/gevals.git
+   cd gevals
+   go build -o gevals ./cmd/gevals
+   ```
+
+2. Start your MCP server using genmcp (if not already running):
+   ```bash
+   genmcp run -f mcpfile.yaml
+   ```
+   This will start the server at localhost:8080
+
+3. Run the evaluation (from the gevals directory, pointing to this evals folder):
+   ```bash
+   ./gevals eval /path/to/this/evals/eval.yaml
+   ```
+   The command output will show you what succeeded or failed.
+
+4. For detailed information, review the output file: `gevals-startup-issue-tracker-evals-out.json`
+
+## Example: The "most-requested-feature" Task
+
+Our evaluation includes a task that asks: **"What is the most requested feature for my app?"**
+
+The task expects the agent to:
+1. Call `get_features-top` to get the top feature
+2. Call `get_features-id` to get full details about that feature
+3. Respond with information about dark mode being the most requested feature
+
+### Initial Failure & The Fix
+
+When we first ran this evaluation, it **failed** because the agent only called `get_features-top` but didn't call `get_features-id` to get the full details. This happened because the tool description didn't make it clear that both calls were necessary.
+
+**The problem:** The original `get_features-top` description was:
+```yaml
+description: Returns the feature with the most upvotes
+```
+
+**The solution:** We updated the description in `mcpfile.yaml` (line 43) to:
+```yaml
+description: Returns the feature with the most upvotes. Always call get_features-id to give the user all the details about the top requested feature
+```
+
+This demonstrates the core value of gevals: **it helps you discover and fix discoverability issues in your MCP server by showing how AI agents actually interact with your tools.**
+
+## Understanding the Assertions
+
+In `eval.yaml`, we define assertions that must pass for the evaluation to succeed:
+
+```yaml
+assertions:
+  toolsUsed:
+    - server: features
+      tool: get_features-top
+    - server: features
+      tool: get_features-id
+```
+
+This asserts that both tools must be called during the task. If the agent doesn't discover or use these tools, the evaluation fails, signaling that your tool descriptions or server design needs improvement.
+
+## Key Takeaways
+
+✅ **Use gevals to validate your MCP server design** - Not just functionality, but discoverability
+
+✅ **Tool descriptions matter** - They guide the AI agent to use tools correctly
+
+✅ **Assertions help enforce best practices** - Ensure agents use tools in the intended sequence
+
+✅ **Iterative improvement** - Use failed evaluations to refine your tool descriptions and schemas
+
+## Next Steps
+
+1. Add more tasks to the `tasks/` directory to test other tool combinations
+2. Run evaluations regularly as you add new tools or modify existing ones
+3. Use LLM judge verification (configured in `eval.yaml`) to validate response quality
+4. Review `gevals-*-out.json` files to understand agent behavior patterns
+
+For more information, visit the [gevals repository](https://github.com/genmcp/gevals).

--- a/examples/http-conversion/evals/claude-code.yaml
+++ b/examples/http-conversion/evals/claude-code.yaml
@@ -1,0 +1,10 @@
+kind: Agent
+metadata:
+  name: "claude-code"
+commands:
+  useVirtualHome: false
+  argTemplateMcpServer: "--mcp-config {{ .File }}"
+  argTemplateAllowedTools: "mcp__{{ .ServerName }}__{{ .ToolName }}"
+  allowedToolsJoinSeparator: ","
+  runPrompt: |-
+    claude {{ .McpServerFileArgs }} --strict-mcp-config --allowedTools "{{ .AllowedToolArgs }}" --print "{{ .Prompt }}"

--- a/examples/http-conversion/evals/eval.yaml
+++ b/examples/http-conversion/evals/eval.yaml
@@ -1,0 +1,20 @@
+kind: Eval
+metadata:
+  name: startup-issue-tracker-evals
+config:
+  agentFile: claude-code.yaml
+  mcpConfigFile: mcp-config.yaml
+  llmJudge:
+    env:
+      baseUrlKey: MODEL_BASE_URL
+      apiKeyKey: MODEL_API_KEY
+      modelNameKey: MODEL_NAME
+  taskSets:
+    - path: ./tasks/most-requested-feature/most-requested-feature.yaml
+      assertions:
+        toolsUsed:
+          - server: features
+            tool: get_features-top
+          - server: features
+            tool: get_features-id
+

--- a/examples/http-conversion/evals/mcp-config.yaml
+++ b/examples/http-conversion/evals/mcp-config.yaml
@@ -1,0 +1,5 @@
+mcpServers:
+  features:
+    type: http
+    url: http://localhost:8080/mcp
+    enableAllTools: true

--- a/examples/http-conversion/evals/mcpfile.yaml
+++ b/examples/http-conversion/evals/mcpfile.yaml
@@ -1,0 +1,114 @@
+mcpFileVersion: 0.1.0
+name: Feature Request API
+runtime:
+  loggingConfig: null
+  streamableHttpConfig:
+    port: 8080
+    stateless: false
+  transportProtocol: streamablehttp
+tools:
+- annotations: null
+  description: Returns a list of all features sorted by upvotes (highest first)
+  inputSchema:
+    type: object
+  invocation:
+    http:
+      method: GET
+      url: http://localhost:9090/features
+  name: get_features
+  title: Get all features
+- annotations: null
+  description: Create a new feature request
+  inputSchema:
+    properties:
+      description:
+        description: Detailed description of the feature
+        type: string
+      details:
+        description: Detailed implementation notes for the feature
+        type: string
+      title:
+        description: Feature title
+        type: string
+    required:
+    - title
+    type: object
+  invocation:
+    http:
+      method: POST
+      url: http://localhost:9090/features
+  name: post_features
+  title: Add new feature
+- annotations: null
+  description: Returns the feature with the most upvotes. Always call get_features-id to give the user all the details about the top requested feature
+  inputSchema:
+    type: object
+  invocation:
+    http:
+      method: GET
+      url: http://localhost:9090/features/top
+  name: get_features-top
+  title: Get top feature
+- annotations: null
+  description: Returns detailed information about a specific feature
+  inputSchema:
+    properties:
+      id:
+        type: integer
+    required:
+    - id
+    type: object
+  invocation:
+    http:
+      method: GET
+      url: http://localhost:9090/features/{id}
+  name: get_features-id
+  title: Get feature details
+- annotations: null
+  description: Delete a specific feature request
+  inputSchema:
+    properties:
+      id:
+        type: integer
+    required:
+    - id
+    type: object
+  invocation:
+    http:
+      method: DELETE
+      url: http://localhost:9090/features/{id}
+  name: delete_features-id
+  title: Delete feature
+- annotations: null
+  description: Increment the upvote count for a specific feature
+  inputSchema:
+    properties:
+      feature_id:
+        description: ID of the feature to vote for
+        type: integer
+    required:
+    - feature_id
+    type: object
+  invocation:
+    http:
+      method: POST
+      url: http://localhost:9090/features/vote
+  name: post_features-vote
+  title: Vote for feature
+- annotations: null
+  description: Mark a specific feature request as completed
+  inputSchema:
+    properties:
+      feature_id:
+        description: ID of the feature to mark as completed
+        type: integer
+    required:
+    - feature_id
+    type: object
+  invocation:
+    http:
+      method: POST
+      url: http://localhost:9090/features/complete
+  name: post_features-complete
+  title: Mark feature as completed
+version: 0.0.1

--- a/examples/http-conversion/evals/tasks/most-requested-feature/most-requested-feature.yaml
+++ b/examples/http-conversion/evals/tasks/most-requested-feature/most-requested-feature.yaml
@@ -1,0 +1,9 @@
+kind: Task
+metadata:
+  name: most-requested-feature
+  difficulty: easy
+steps:
+  prompt:
+    inline: What is the most requested feature for my app?
+  verify:
+    contains: The most requested feature is dark mode, with support for features like automatic detection of system preference and a manual toggle in user settings.


### PR DESCRIPTION
## What this PR does / why we need it:

This shows users how to evaluate their MCP server with gevals


## Proposed Changes
- Add gevals files
- Add simple README (created collaboratively with @claude) to explain what is going on in the gevals demo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive README documenting the evaluation workflow for MCP servers, including configuration guidance and implementation examples.

* **New Features**
  * Included example evaluation task and configuration files demonstrating automated testing of MCP server functionality with assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->