### PR TITLE
fix: publish release now signs artifacts with cosign as well

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -121,7 +121,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@v4
 
       - name: Build genmcp CLI
         env:

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -137,7 +137,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@v4
 
       - name: Build genmcp CLI
         env:

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -139,7 +139,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@v4
 
       - name: Build genmcp CLI
         env:


### PR DESCRIPTION
This is a quick fix to the "Publish Release" workflow to sign the binaries there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Download verification: Release packages now include cryptographic signature files (.sig and .pem) that enable users to verify the authenticity and integrity of CLI and server artifacts. Signature files can be validated using standard cryptographic tools to ensure that downloads have not been tampered with and originate from official trusted sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->