### PR TITLE
Update the schema generator to handle InvocationConfigWrapper with a custom mapper

### DIFF
--- a/hack/jsonschemagen/main.go
+++ b/hack/jsonschemagen/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/invopop/jsonschema"
 
+	"github.com/genmcp/gen-mcp/pkg/invocation"
 	"github.com/genmcp/gen-mcp/pkg/invocation/cli"
 	"github.com/genmcp/gen-mcp/pkg/invocation/extends"
 	"github.com/genmcp/gen-mcp/pkg/invocation/http"
@@ -360,7 +361,7 @@ func main() {
 		// Don't automatically require all properties - we'll use struct tags to determine this
 		reflector.RequiredFromJSONSchemaTags = true
 
-		// WORKAROUND: Handle google/jsonschema-go Schema type and json.RawMessage
+		// WORKAROUND: Handle google/jsonschema-go Schema type, json.RawMessage, and InvocationConfigWrapper
 		// invopop/jsonschema can't properly reflect google's Schema because it uses
 		// json:"-" tags on the Type field. Instead, we return a detailed meta-schema
 		// that describes JSON Schema itself, providing better IDE autocomplete.
@@ -373,6 +374,46 @@ func main() {
 				return &jsonschema.Schema{
 					Type: "object",
 				}
+			}
+			if t == reflect.TypeOf(&invocation.InvocationConfigWrapper{}) || t == reflect.TypeOf(invocation.InvocationConfigWrapper{}) {
+				// Create a schema that allows an object with one property: http, cli, or extends
+				schema := &jsonschema.Schema{
+					Type:        "object",
+					Description: "Invocation configuration with exactly one type key (http, cli, or extends)",
+					OneOf: []*jsonschema.Schema{
+						{
+							Type:                 "object",
+							Properties:           jsonschema.NewProperties(),
+							Required:             []string{"http"},
+							AdditionalProperties: jsonschema.FalseSchema,
+						},
+						{
+							Type:                 "object",
+							Properties:           jsonschema.NewProperties(),
+							Required:             []string{"cli"},
+							AdditionalProperties: jsonschema.FalseSchema,
+						},
+						{
+							Type:                 "object",
+							Properties:           jsonschema.NewProperties(),
+							Required:             []string{"extends"},
+							AdditionalProperties: jsonschema.FalseSchema,
+						},
+					},
+				}
+				// Add the http property with reference to HttpInvocationConfig
+				schema.OneOf[0].Properties.Set("http", &jsonschema.Schema{
+					Ref: "#/$defs/HttpInvocationConfig",
+				})
+				// Add the cli property with reference to CliInvocationConfig
+				schema.OneOf[1].Properties.Set("cli", &jsonschema.Schema{
+					Ref: "#/$defs/CliInvocationConfig",
+				})
+				// Add the extends property with reference to ExtendsConfig
+				schema.OneOf[2].Properties.Set("extends", &jsonschema.Schema{
+					Ref: "#/$defs/ExtendsConfig",
+				})
+				return schema
 			}
 			return nil
 		}

--- a/specs/mcpfile-schema-0.1.0.json
+++ b/specs/mcpfile-schema-0.1.0.json
@@ -102,50 +102,6 @@
       ],
       "description": "The configuration for making an HTTP request."
     },
-    "InvocationConfigWrapper": {
-      "oneOf": [
-        {
-          "properties": {
-            "http": {
-              "$ref": "#/$defs/HttpInvocationConfig"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "http"
-          ],
-          "description": "An invocation configuration using HTTP."
-        },
-        {
-          "properties": {
-            "cli": {
-              "$ref": "#/$defs/CliInvocationConfig"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "cli"
-          ],
-          "description": "An invocation configuration using CLI."
-        },
-        {
-          "properties": {
-            "extends": {
-              "$ref": "#/$defs/ExtendsConfig"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "extends"
-          ],
-          "description": "An invocation configuration that extends a base configuration."
-        }
-      ],
-      "description": "A wrapper for invocation configurations. Must contain exactly one invocation type key (http, cli, or extends) with its corresponding configuration."
-    },
     "LoggingConfig": {
       "properties": {
         "level": {
@@ -209,7 +165,46 @@
         },
         "invocationBases": {
           "additionalProperties": {
-            "$ref": "#/$defs/InvocationConfigWrapper"
+            "oneOf": [
+              {
+                "properties": {
+                  "http": {
+                    "$ref": "#/$defs/HttpInvocationConfig"
+                  }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                  "http"
+                ]
+              },
+              {
+                "properties": {
+                  "cli": {
+                    "$ref": "#/$defs/CliInvocationConfig"
+                  }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                  "cli"
+                ]
+              },
+              {
+                "properties": {
+                  "extends": {
+                    "$ref": "#/$defs/ExtendsConfig"
+                  }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                  "extends"
+                ]
+              }
+            ],
+            "type": "object",
+            "description": "Invocation configuration with exactly one type key (http, cli, or extends)"
           },
           "type": "object",
           "description": "InvocationBases contains base configs for invocations"
@@ -588,6 +583,42 @@
         "invocation": {
           "oneOf": [
             {
+              "properties": {
+                "http": {
+                  "$ref": "#/$defs/HttpInvocationConfig"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "http"
+              ]
+            },
+            {
+              "properties": {
+                "cli": {
+                  "$ref": "#/$defs/CliInvocationConfig"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "cli"
+              ]
+            },
+            {
+              "properties": {
+                "extends": {
+                  "$ref": "#/$defs/ExtendsConfig"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "extends"
+              ]
+            },
+            {
               "$ref": "#/$defs/HttpInvocationConfig"
             },
             {
@@ -597,6 +628,7 @@
               "$ref": "#/$defs/ExtendsConfig"
             }
           ],
+          "type": "object",
           "description": "Object describing how to invoke the prompt."
         },
         "requiredScopes": {
@@ -984,6 +1016,42 @@
         "invocation": {
           "oneOf": [
             {
+              "properties": {
+                "http": {
+                  "$ref": "#/$defs/HttpInvocationConfig"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "http"
+              ]
+            },
+            {
+              "properties": {
+                "cli": {
+                  "$ref": "#/$defs/CliInvocationConfig"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "cli"
+              ]
+            },
+            {
+              "properties": {
+                "extends": {
+                  "$ref": "#/$defs/ExtendsConfig"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "extends"
+              ]
+            },
+            {
               "$ref": "#/$defs/HttpInvocationConfig"
             },
             {
@@ -993,6 +1061,7 @@
               "$ref": "#/$defs/ExtendsConfig"
             }
           ],
+          "type": "object",
           "description": "Object describing how to invoke the resource."
         },
         "requiredScopes": {
@@ -1350,6 +1419,42 @@
         "invocation": {
           "oneOf": [
             {
+              "properties": {
+                "http": {
+                  "$ref": "#/$defs/HttpInvocationConfig"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "http"
+              ]
+            },
+            {
+              "properties": {
+                "cli": {
+                  "$ref": "#/$defs/CliInvocationConfig"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "cli"
+              ]
+            },
+            {
+              "properties": {
+                "extends": {
+                  "$ref": "#/$defs/ExtendsConfig"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "extends"
+              ]
+            },
+            {
               "$ref": "#/$defs/HttpInvocationConfig"
             },
             {
@@ -1359,6 +1464,7 @@
               "$ref": "#/$defs/ExtendsConfig"
             }
           ],
+          "type": "object",
           "description": "Object describing how to invoke the resource template."
         },
         "requiredScopes": {
@@ -1804,6 +1910,42 @@
         "invocation": {
           "oneOf": [
             {
+              "properties": {
+                "http": {
+                  "$ref": "#/$defs/HttpInvocationConfig"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "http"
+              ]
+            },
+            {
+              "properties": {
+                "cli": {
+                  "$ref": "#/$defs/CliInvocationConfig"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "cli"
+              ]
+            },
+            {
+              "properties": {
+                "extends": {
+                  "$ref": "#/$defs/ExtendsConfig"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "extends"
+              ]
+            },
+            {
               "$ref": "#/$defs/HttpInvocationConfig"
             },
             {
@@ -1813,6 +1955,7 @@
               "$ref": "#/$defs/ExtendsConfig"
             }
           ],
+          "type": "object",
           "description": "Object describing how to execute the tool."
         },
         "requiredScopes": {

--- a/specs/mcpfile-schema.json
+++ b/specs/mcpfile-schema.json
@@ -102,50 +102,6 @@
       ],
       "description": "The configuration for making an HTTP request."
     },
-    "InvocationConfigWrapper": {
-      "oneOf": [
-        {
-          "properties": {
-            "http": {
-              "$ref": "#/$defs/HttpInvocationConfig"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "http"
-          ],
-          "description": "An invocation configuration using HTTP."
-        },
-        {
-          "properties": {
-            "cli": {
-              "$ref": "#/$defs/CliInvocationConfig"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "cli"
-          ],
-          "description": "An invocation configuration using CLI."
-        },
-        {
-          "properties": {
-            "extends": {
-              "$ref": "#/$defs/ExtendsConfig"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "extends"
-          ],
-          "description": "An invocation configuration that extends a base configuration."
-        }
-      ],
-      "description": "A wrapper for invocation configurations. Must contain exactly one invocation type key (http, cli, or extends) with its corresponding configuration."
-    },
     "LoggingConfig": {
       "properties": {
         "level": {
@@ -209,7 +165,46 @@
         },
         "invocationBases": {
           "additionalProperties": {
-            "$ref": "#/$defs/InvocationConfigWrapper"
+            "oneOf": [
+              {
+                "properties": {
+                  "http": {
+                    "$ref": "#/$defs/HttpInvocationConfig"
+                  }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                  "http"
+                ]
+              },
+              {
+                "properties": {
+                  "cli": {
+                    "$ref": "#/$defs/CliInvocationConfig"
+                  }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                  "cli"
+                ]
+              },
+              {
+                "properties": {
+                  "extends": {
+                    "$ref": "#/$defs/ExtendsConfig"
+                  }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                  "extends"
+                ]
+              }
+            ],
+            "type": "object",
+            "description": "Invocation configuration with exactly one type key (http, cli, or extends)"
           },
           "type": "object",
           "description": "InvocationBases contains base configs for invocations"
@@ -588,6 +583,42 @@
         "invocation": {
           "oneOf": [
             {
+              "properties": {
+                "http": {
+                  "$ref": "#/$defs/HttpInvocationConfig"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "http"
+              ]
+            },
+            {
+              "properties": {
+                "cli": {
+                  "$ref": "#/$defs/CliInvocationConfig"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "cli"
+              ]
+            },
+            {
+              "properties": {
+                "extends": {
+                  "$ref": "#/$defs/ExtendsConfig"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "extends"
+              ]
+            },
+            {
               "$ref": "#/$defs/HttpInvocationConfig"
             },
             {
@@ -597,6 +628,7 @@
               "$ref": "#/$defs/ExtendsConfig"
             }
           ],
+          "type": "object",
           "description": "Object describing how to invoke the prompt."
         },
         "requiredScopes": {
@@ -984,6 +1016,42 @@
         "invocation": {
           "oneOf": [
             {
+              "properties": {
+                "http": {
+                  "$ref": "#/$defs/HttpInvocationConfig"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "http"
+              ]
+            },
+            {
+              "properties": {
+                "cli": {
+                  "$ref": "#/$defs/CliInvocationConfig"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "cli"
+              ]
+            },
+            {
+              "properties": {
+                "extends": {
+                  "$ref": "#/$defs/ExtendsConfig"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "extends"
+              ]
+            },
+            {
               "$ref": "#/$defs/HttpInvocationConfig"
             },
             {
@@ -993,6 +1061,7 @@
               "$ref": "#/$defs/ExtendsConfig"
             }
           ],
+          "type": "object",
           "description": "Object describing how to invoke the resource."
         },
         "requiredScopes": {
@@ -1350,6 +1419,42 @@
         "invocation": {
           "oneOf": [
             {
+              "properties": {
+                "http": {
+                  "$ref": "#/$defs/HttpInvocationConfig"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "http"
+              ]
+            },
+            {
+              "properties": {
+                "cli": {
+                  "$ref": "#/$defs/CliInvocationConfig"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "cli"
+              ]
+            },
+            {
+              "properties": {
+                "extends": {
+                  "$ref": "#/$defs/ExtendsConfig"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "extends"
+              ]
+            },
+            {
               "$ref": "#/$defs/HttpInvocationConfig"
             },
             {
@@ -1359,6 +1464,7 @@
               "$ref": "#/$defs/ExtendsConfig"
             }
           ],
+          "type": "object",
           "description": "Object describing how to invoke the resource template."
         },
         "requiredScopes": {
@@ -1804,6 +1910,42 @@
         "invocation": {
           "oneOf": [
             {
+              "properties": {
+                "http": {
+                  "$ref": "#/$defs/HttpInvocationConfig"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "http"
+              ]
+            },
+            {
+              "properties": {
+                "cli": {
+                  "$ref": "#/$defs/CliInvocationConfig"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "cli"
+              ]
+            },
+            {
+              "properties": {
+                "extends": {
+                  "$ref": "#/$defs/ExtendsConfig"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "extends"
+              ]
+            },
+            {
               "$ref": "#/$defs/HttpInvocationConfig"
             },
             {
@@ -1813,6 +1955,7 @@
               "$ref": "#/$defs/ExtendsConfig"
             }
           ],
+          "type": "object",
           "description": "Object describing how to execute the tool."
         },
         "requiredScopes": {


### PR DESCRIPTION
I noticed the mcpfile.yaml was not validating with the schema

## Proposed Changes
- Update the schema generator to handle InvocationConfigWrapper with a custom mapper



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Schema Updates**
  * Streamlined MCP file schema structure by consolidating invocation configuration definitions with explicit inline schemas and validation rules across entity types, improving consistency and clarity for schema validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->