### PR TITLE
Add entry in dependabot for jsonschemagen go mod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,35 @@ updates:
         update-types:
           - "major"
 
+  # Go dependencies for jsonschemagen
+  - package-ecosystem: "gomod"
+    directory: "/hack/jsonschemagen"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      time: "10:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "@genmcp/maintainers"
+    assignees:
+      - "@genmcp/maintainers"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    groups:
+      jsonschemagen-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"
+      jsonschemagen-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+
   # GitHub Actions dependencies
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION




## Proposed Changes
- Add entry in dependabot for `hack/jsonschemagen/go.mod`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration for improved dependency tracking and updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->