### PR TITLE
fix(http): do not include header vars in request body/query params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.2.1]
+
+### Fixed
+- HTTP invocations which have headers do not also include those variables in the request body/query. (#247)
+
 ## [v0.2.0]
 
 ### Added

--- a/pkg/invocation/http/http_invocation_test.go
+++ b/pkg/invocation/http/http_invocation_test.go
@@ -218,12 +218,43 @@ func TestHttpInvocation(t *testing.T) {
 			expectedPath:      "/items",
 			expectedBody: map[string]any{
 				"path": map[string]any{
-					"part1": float64(42),
 					"part2": "test",
 				},
 			},
 			expectedHeaders: nethttp.Header{
 				"X-User-Id": []string{"42"},
+			},
+		},
+		{
+			name:         "POST request excludes header params from body",
+			responseCode: 200,
+			responseBody: func() []byte { return []byte("ok") },
+			urlTemplate:  "/data",
+			headerTemplates: map[string]string{
+				"X-Limit": "{limit}",
+			},
+			schema: resolvedWithPath,
+			method: "POST",
+			request: &mcp.CallToolRequest{
+				Params: &mcp.CallToolParamsRaw{
+					Arguments: []byte(`{"limit": 100, "search": "test"}`),
+				},
+			},
+			expectedResult: &mcp.CallToolResult{
+				Content: []mcp.Content{
+					&mcp.TextContent{
+						Text: "ok",
+					},
+				},
+			},
+			expectedReqMethod: "POST",
+			expectedQuery:     make(neturl.Values),
+			expectedPath:      "/data",
+			expectedBody: map[string]any{
+				"search": "test",
+			},
+			expectedHeaders: nethttp.Header{
+				"X-Limit": []string{"100"},
 			},
 		},
 		{
@@ -316,6 +347,37 @@ func TestHttpInvocation(t *testing.T) {
 				"search": {"test query"},
 			},
 			expectedPath: "/search",
+		},
+		{
+			name:         "GET request excludes header params from query",
+			responseCode: 200,
+			responseBody: func() []byte { return []byte("ok") },
+			urlTemplate:  "/data",
+			headerTemplates: map[string]string{
+				"X-Limit": "{limit}",
+			},
+			schema: resolvedWithPath,
+			method: "GET",
+			request: &mcp.CallToolRequest{
+				Params: &mcp.CallToolParamsRaw{
+					Arguments: []byte(`{"limit": 100, "search": "test"}`),
+				},
+			},
+			expectedResult: &mcp.CallToolResult{
+				Content: []mcp.Content{
+					&mcp.TextContent{
+						Text: "ok",
+					},
+				},
+			},
+			expectedReqMethod: "GET",
+			expectedQuery: map[string][]string{
+				"search": {"test"},
+			},
+			expectedPath: "/data",
+			expectedHeaders: nethttp.Header{
+				"X-Limit": []string{"100"},
+			},
 		},
 	}
 


### PR DESCRIPTION
This PR fixes a bug where variables that are being used as headers on the request are actually included in the request body/query params.

Currently, the way variables are used elsewhere (just the request path), we exclude them from the request body/query in they are set as a variable in the request path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Header template variables are now excluded from request bodies and query parameters, preventing duplicate or misplaced parameters in HTTP requests.

* **Tests**
  * Added and updated test cases to validate headers are sourced from header templates and omitted from body/query construction.

* **Documentation**
  * Changelog updated with an unreleased entry describing the fix for header parameter handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->