### PR TITLE
fix: binary downloader works with path-separated cache name

### DIFF
--- a/pkg/utils/binarycache/binary_downloader.go
+++ b/pkg/utils/binarycache/binary_downloader.go
@@ -115,7 +115,7 @@ func (bd *BinaryDownloader) verifyAndExtractZip(zipPath, version, goos, goarch s
 		return "", err
 	}
 
-	extractDir, err := os.MkdirTemp("", fmt.Sprintf("%s-extract-*", bd.cfg.GetCacheName()))
+	extractDir, err := os.MkdirTemp("", fmt.Sprintf("%s-extract-*", bd.cfg.GetSanitizedCacheName()))
 	if err != nil {
 		return "", fmt.Errorf("failed to create extract dir: %w", err)
 	}
@@ -131,7 +131,7 @@ func (bd *BinaryDownloader) verifyAndExtractZip(zipPath, version, goos, goarch s
 
 // verifyZipWithBundle downloads a fresh bundle and verifies a zip file with Sigstore
 func (bd *BinaryDownloader) verifyZipWithBundle(zipPath, version, goos, goarch string) error {
-	tempDir, err := os.MkdirTemp("", fmt.Sprintf("%s-verify-*", bd.cfg.GetCacheName()))
+	tempDir, err := os.MkdirTemp("", fmt.Sprintf("%s-verify-*", bd.cfg.GetSanitizedCacheName()))
 	if err != nil {
 		return fmt.Errorf("failed to create temp dir: %w", err)
 	}
@@ -156,7 +156,7 @@ func (bd *BinaryDownloader) verifyZipWithBundle(zipPath, version, goos, goarch s
 // downloadAndVerify downloads a binary and verifies it with Sigstore
 // Returns the path to the verified zip file in temp directory.
 func (bd *BinaryDownloader) downloadAndVerify(version, goos, goarch string) (string, error) {
-	tempDir, err := os.MkdirTemp("", fmt.Sprintf("%s-download-*", bd.cfg.GetCacheName()))
+	tempDir, err := os.MkdirTemp("", fmt.Sprintf("%s-download-*", bd.cfg.GetSanitizedCacheName()))
 	if err != nil {
 		return "", fmt.Errorf("failed to create temp dir: %w", err)
 	}

--- a/pkg/utils/binarycache/binary_downloader_test.go
+++ b/pkg/utils/binarycache/binary_downloader_test.go
@@ -43,6 +43,28 @@ func TestBinaryDownloader_VerboseOutput(t *testing.T) {
 	}
 }
 
+func TestBinaryDownloader_PathSeparatorInCacheName(t *testing.T) {
+	// Test that cache names with path separators work correctly
+	// This is important for users who want cache names like ".gevals/something"
+	cfg := &Config{
+		CacheName:    ".gevals/something",
+		BinaryPrefix: "test-binary",
+	}
+
+	bd, err := NewBinaryDownloader(cfg)
+	if err != nil {
+		if strings.Contains(err.Error(), "fetch trusted root") ||
+			strings.Contains(err.Error(), "TUF") ||
+			strings.Contains(err.Error(), "network") {
+			t.Skipf("Skipping test: requires network access: %v", err)
+		}
+		t.Fatalf("Failed to create downloader with path separator in cache name: %v", err)
+	}
+	if bd == nil {
+		t.Fatal("Expected non-nil downloader")
+	}
+}
+
 func TestBinaryDownloader_SilentMode(t *testing.T) {
 	old := os.Stdout
 	r, w, _ := os.Pipe()

--- a/pkg/utils/binarycache/config.go
+++ b/pkg/utils/binarycache/config.go
@@ -40,6 +40,22 @@ func (cfg *Config) GetCacheName() string {
 	return cfg.CacheName
 }
 
+// GetSanitizedCacheName returns the cache name with path separators replaced,
+// making it safe for use in temp directory prefixes and filenames.
+func (cfg *Config) GetSanitizedCacheName() string {
+	name := cfg.GetCacheName()
+	// Replace path separators with underscores to make it filesystem-safe
+	result := make([]byte, len(name))
+	for i := 0; i < len(name); i++ {
+		if name[i] == '/' || name[i] == '\\' {
+			result[i] = '_'
+		} else {
+			result[i] = name[i]
+		}
+	}
+	return string(result)
+}
+
 func (cfg *Config) GetBinaryPrefix() string {
 	if cfg == nil || cfg.BinaryPrefix == "" {
 		return DefaultBinaryPrefix


### PR DESCRIPTION
In gevals, we use the binary downloader to pull in extensions. We want those to be in directories like `.gevals/extension-name`. However, this fails with the current setup of the package as it uses the cache name to create temp dirs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache directory handling to ensure proper sanitization of cache names containing path separators, preventing potential filesystem conflicts.

* **Tests**
  * Added validation test for handling cache names with path separators.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->