### PR TITLE
feat: add support for custom CA certificates in outbound HTTP requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Custom CA certificate support for outbound HTTP requests via `clientTlsConfig` in `mcpserver.yaml`. This allows MCP servers to connect to internal services that use certificates signed by corporate or private CAs. (#285, fixes #284)
+
 ## [v0.2.2]
 
 ## Fixed

--- a/pkg/config/server/httpclient.go
+++ b/pkg/config/server/httpclient.go
@@ -1,0 +1,152 @@
+package server
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// GetHTTPClient returns a configured HTTP client based on the ClientTLSConfig.
+// The client is created once and cached for subsequent calls.
+// If ClientTLSConfig is nil, it returns a default HTTP client with reasonable timeouts.
+func (sr *ServerRuntime) GetHTTPClient() (*http.Client, error) {
+	if sr == nil {
+		return http.DefaultClient, nil
+	}
+
+	sr.httpClientOnce.Do(func() {
+		sr.httpClient, sr.httpClientErr = sr.buildHTTPClient()
+	})
+
+	return sr.httpClient, sr.httpClientErr
+}
+
+// buildHTTPClient creates an HTTP client with custom TLS configuration if specified.
+// If no ClientTLSConfig is provided, returns a basic client matching the original behavior.
+// When custom TLS is configured, we clone http.DefaultTransport to preserve important
+// defaults like ProxyFromEnvironment, TLSHandshakeTimeout, and HTTP/2 support.
+func (sr *ServerRuntime) buildHTTPClient() (*http.Client, error) {
+	// If no custom TLS config, return a simple client matching original behavior
+	// (nil Transport means http.DefaultTransport is used implicitly)
+	if sr.ClientTLSConfig == nil {
+		return &http.Client{}, nil
+	}
+
+	// Build TLS config from user settings
+	tlsConfig, err := sr.ClientTLSConfig.BuildTLSConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build TLS config: %w", err)
+	}
+
+	// Clone DefaultTransport to preserve proxy settings, timeouts, connection pooling, and HTTP/2.
+	// Guard the type assertion in case a host application replaced DefaultTransport.
+	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil, fmt.Errorf("http.DefaultTransport is not *http.Transport; cannot apply custom TLS config")
+	}
+	transport := defaultTransport.Clone()
+	transport.TLSClientConfig = tlsConfig
+
+	return &http.Client{
+		Transport: transport,
+	}, nil
+}
+
+// BuildTLSConfig creates a tls.Config from the ClientTLSConfig settings.
+// It loads CA certificates from the specified files and/or directory.
+func (c *ClientTLSConfig) BuildTLSConfig() (*tls.Config, error) {
+	if c == nil {
+		return nil, nil
+	}
+
+	// Start with the system cert pool
+	rootCAs, err := x509.SystemCertPool()
+	if err != nil {
+		// On some systems (e.g., Windows), we may not be able to get the system pool
+		// In that case, create an empty pool
+		rootCAs = x509.NewCertPool()
+	}
+
+	// Load CA certificates from individual files
+	for _, certFile := range c.CACertFiles {
+		if err := appendCertFromFile(rootCAs, certFile); err != nil {
+			return nil, fmt.Errorf("failed to load CA cert from %s: %w", certFile, err)
+		}
+	}
+
+	// Load CA certificates from directory
+	if c.CACertDir != "" {
+		if err := appendCertsFromDir(rootCAs, c.CACertDir); err != nil {
+			return nil, fmt.Errorf("failed to load CA certs from directory %s: %w", c.CACertDir, err)
+		}
+	}
+
+	tlsConfig := &tls.Config{
+		RootCAs:            rootCAs,
+		InsecureSkipVerify: c.InsecureSkipVerify, //nolint:gosec // User explicitly requested insecure mode
+	}
+
+	return tlsConfig, nil
+}
+
+// appendCertFromFile reads a PEM-encoded certificate file and appends it to the cert pool.
+func appendCertFromFile(pool *x509.CertPool, certFile string) error {
+	certPEM, err := os.ReadFile(certFile)
+	if err != nil {
+		return fmt.Errorf("failed to read certificate file: %w", err)
+	}
+
+	if !pool.AppendCertsFromPEM(certPEM) {
+		return fmt.Errorf("failed to parse certificate from %s", certFile)
+	}
+
+	return nil
+}
+
+// appendCertsFromDir loads all .pem and .crt files from a directory into the cert pool.
+// Unlike caCertFiles which fails on any error, directory loading is lenient:
+// - Invalid or unreadable cert files are skipped with a warning
+// - This matches the behavior of system CA directories which may contain various file types
+//
+// Note: Warnings are written to stderr because this function is called during server
+// initialization (via GetHTTPClient -> buildHTTPClient -> BuildTLSConfig) before the
+// structured logger is fully initialized. This follows the same pattern used in
+// GetBaseLogger() for initialization-time errors.
+func appendCertsFromDir(pool *x509.CertPool, dirPath string) error {
+	entries, err := os.ReadDir(dirPath)
+	if err != nil {
+		return fmt.Errorf("failed to read directory: %w", err)
+	}
+
+	loadedCount := 0
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		ext := strings.ToLower(filepath.Ext(name))
+		if ext != ".pem" && ext != ".crt" {
+			continue
+		}
+
+		certPath := filepath.Join(dirPath, name)
+		if err := appendCertFromFile(pool, certPath); err != nil {
+			// Warn but continue - directory may contain non-cert files or expired certs
+			// Using stderr since logger is not available during initialization
+			fmt.Fprintf(os.Stderr, "Warning: skipping CA cert %s: %v\n", certPath, err)
+			continue
+		}
+		loadedCount++
+	}
+
+	if loadedCount == 0 {
+		fmt.Fprintf(os.Stderr, "Warning: no valid CA certificates found in %s\n", dirPath)
+	}
+
+	return nil
+}

--- a/pkg/config/server/httpclient_test.go
+++ b/pkg/config/server/httpclient_test.go
@@ -1,0 +1,244 @@
+package server
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientTLSConfig_BuildTLSConfig(t *testing.T) {
+	tt := []struct {
+		name           string
+		config         *ClientTLSConfig
+		setupFunc      func(t *testing.T) (cleanup func())
+		expectError    bool
+		errorContains  string
+		validateConfig func(t *testing.T, config *ClientTLSConfig)
+	}{
+		{
+			name:   "nil config returns nil",
+			config: nil,
+		},
+		{
+			name:   "empty config returns valid TLS config",
+			config: &ClientTLSConfig{},
+		},
+		{
+			name: "insecureSkipVerify is set correctly",
+			config: &ClientTLSConfig{
+				InsecureSkipVerify: true,
+			},
+			validateConfig: func(t *testing.T, config *ClientTLSConfig) {
+				tlsConfig, err := config.BuildTLSConfig()
+				require.NoError(t, err)
+				assert.True(t, tlsConfig.InsecureSkipVerify)
+			},
+		},
+		{
+			name: "invalid CA cert file path returns error",
+			config: &ClientTLSConfig{
+				CACertFiles: []string{"/nonexistent/path/to/ca.pem"},
+			},
+			expectError:   true,
+			errorContains: "failed to load CA cert",
+		},
+		{
+			name: "invalid CA cert directory returns error",
+			config: &ClientTLSConfig{
+				CACertDir: "/nonexistent/directory",
+			},
+			expectError:   true,
+			errorContains: "failed to load CA certs from directory",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.setupFunc != nil {
+				cleanup := tc.setupFunc(t)
+				defer cleanup()
+			}
+
+			if tc.validateConfig != nil {
+				tc.validateConfig(t, tc.config)
+				return
+			}
+
+			tlsConfig, err := tc.config.BuildTLSConfig()
+
+			if tc.expectError {
+				assert.Error(t, err)
+				if tc.errorContains != "" {
+					assert.Contains(t, err.Error(), tc.errorContains)
+				}
+			} else {
+				assert.NoError(t, err)
+				if tc.config != nil {
+					assert.NotNil(t, tlsConfig)
+				}
+			}
+		})
+	}
+}
+
+func TestClientTLSConfig_LoadCACertFiles(t *testing.T) {
+	// Create a temporary directory
+	tmpDir, err := os.MkdirTemp("", "genmcp-test-certs")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// Generate a test CA certificate
+	certPEM := generateTestCACert(t)
+	certPath := filepath.Join(tmpDir, "test-ca.pem")
+	err = os.WriteFile(certPath, certPEM, 0644)
+	require.NoError(t, err)
+
+	config := &ClientTLSConfig{
+		CACertFiles: []string{certPath},
+	}
+
+	tlsConfig, err := config.BuildTLSConfig()
+	require.NoError(t, err)
+	assert.NotNil(t, tlsConfig)
+	assert.NotNil(t, tlsConfig.RootCAs)
+}
+
+func TestClientTLSConfig_LoadCACertDir(t *testing.T) {
+	// Create a temporary directory
+	tmpDir, err := os.MkdirTemp("", "genmcp-test-certs")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// Generate and write test CA certificates
+	cert1PEM := generateTestCACert(t)
+	cert2PEM := generateTestCACert(t)
+
+	err = os.WriteFile(filepath.Join(tmpDir, "ca1.pem"), cert1PEM, 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, "ca2.crt"), cert2PEM, 0644)
+	require.NoError(t, err)
+
+	// Also write a non-cert file that should be ignored
+	err = os.WriteFile(filepath.Join(tmpDir, "readme.txt"), []byte("not a cert"), 0644)
+	require.NoError(t, err)
+
+	config := &ClientTLSConfig{
+		CACertDir: tmpDir,
+	}
+
+	tlsConfig, err := config.BuildTLSConfig()
+	require.NoError(t, err)
+	assert.NotNil(t, tlsConfig)
+	assert.NotNil(t, tlsConfig.RootCAs)
+}
+
+func TestServerRuntime_GetHTTPClient(t *testing.T) {
+	tt := []struct {
+		name        string
+		runtime     *ServerRuntime
+		expectError bool
+	}{
+		{
+			name:    "nil runtime returns default client",
+			runtime: nil,
+		},
+		{
+			name:    "runtime without ClientTLSConfig returns client",
+			runtime: &ServerRuntime{},
+		},
+		{
+			name: "runtime with valid ClientTLSConfig returns client",
+			runtime: &ServerRuntime{
+				ClientTLSConfig: &ClientTLSConfig{
+					InsecureSkipVerify: true,
+				},
+			},
+		},
+		{
+			name: "runtime with invalid CA path returns error",
+			runtime: &ServerRuntime{
+				ClientTLSConfig: &ClientTLSConfig{
+					CACertFiles: []string{"/nonexistent/ca.pem"},
+				},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			client, err := tc.runtime.GetHTTPClient()
+
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, client)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, client)
+			}
+		})
+	}
+}
+
+func TestServerRuntime_GetHTTPClient_Caching(t *testing.T) {
+	runtime := &ServerRuntime{
+		ClientTLSConfig: &ClientTLSConfig{
+			InsecureSkipVerify: true,
+		},
+	}
+
+	// Get client twice
+	client1, err1 := runtime.GetHTTPClient()
+	client2, err2 := runtime.GetHTTPClient()
+
+	require.NoError(t, err1)
+	require.NoError(t, err2)
+
+	// Should return the same instance
+	assert.Same(t, client1, client2, "GetHTTPClient should return cached client")
+}
+
+// generateTestCACert generates a self-signed CA certificate for testing
+func generateTestCACert(t *testing.T) []byte {
+	t.Helper()
+
+	// Generate RSA key
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	// Create certificate template
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Test CA"},
+			CommonName:   "Test CA",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	// Create self-signed certificate
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	require.NoError(t, err)
+
+	// Encode to PEM
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certDER,
+	})
+
+	return certPEM
+}

--- a/pkg/invocation/http/context.go
+++ b/pkg/invocation/http/context.go
@@ -1,0 +1,30 @@
+package http
+
+import (
+	"context"
+	"net/http"
+)
+
+type httpClientKey struct{}
+
+// WithHTTPClient stores an HTTP client in the context.
+// This client will be used by HTTP invokers for outbound requests.
+func WithHTTPClient(ctx context.Context, client *http.Client) context.Context {
+	return context.WithValue(ctx, httpClientKey{}, client)
+}
+
+// HTTPClientFromContext retrieves the HTTP client from the context.
+// If no client is found, it returns http.DefaultClient.
+func HTTPClientFromContext(ctx context.Context) *http.Client {
+	client := ctx.Value(httpClientKey{})
+	if client == nil {
+		return http.DefaultClient
+	}
+
+	httpClient, ok := client.(*http.Client)
+	if !ok {
+		return http.DefaultClient
+	}
+
+	return httpClient
+}

--- a/pkg/invocation/http/context_test.go
+++ b/pkg/invocation/http/context_test.go
@@ -1,0 +1,113 @@
+package http
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHTTPClientFromContext(t *testing.T) {
+	// Create a specific client to test storage/retrieval
+	storedClient := &http.Client{}
+
+	tt := []struct {
+		name           string
+		setupContext   func() context.Context
+		expectedClient *http.Client
+	}{
+		{
+			name: "returns DefaultClient when no client in context",
+			setupContext: func() context.Context {
+				return context.Background()
+			},
+			expectedClient: http.DefaultClient,
+		},
+		{
+			name: "returns DefaultClient when context value is nil",
+			setupContext: func() context.Context {
+				return context.WithValue(context.Background(), httpClientKey{}, nil)
+			},
+			expectedClient: http.DefaultClient,
+		},
+		{
+			name: "returns DefaultClient when context value is wrong type",
+			setupContext: func() context.Context {
+				return context.WithValue(context.Background(), httpClientKey{}, "not a client")
+			},
+			expectedClient: http.DefaultClient,
+		},
+		{
+			name: "returns stored client when valid client in context",
+			setupContext: func() context.Context {
+				return WithHTTPClient(context.Background(), storedClient)
+			},
+			expectedClient: storedClient,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := tc.setupContext()
+			result := HTTPClientFromContext(ctx)
+			assert.Same(t, tc.expectedClient, result)
+		})
+	}
+}
+
+func TestWithHTTPClient(t *testing.T) {
+	tt := []struct {
+		name   string
+		client *http.Client
+	}{
+		{
+			name:   "stores non-nil client in context",
+			client: &http.Client{},
+		},
+		{
+			name:   "stores nil client in context",
+			client: nil,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := WithHTTPClient(context.Background(), tc.client)
+			assert.NotNil(t, ctx)
+
+			// Verify the value was stored
+			stored := ctx.Value(httpClientKey{})
+			assert.Equal(t, tc.client, stored)
+		})
+	}
+}
+
+func TestWithHTTPClientMiddleware(t *testing.T) {
+	tt := []struct {
+		name         string
+		inputClient  *http.Client
+		expectClient *http.Client
+	}{
+		{
+			name:         "nil client uses DefaultClient",
+			inputClient:  nil,
+			expectClient: http.DefaultClient,
+		},
+		{
+			name:         "non-nil client is passed through",
+			inputClient:  &http.Client{},
+			expectClient: nil, // Will check it's not DefaultClient
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			middleware := WithHTTPClientMiddleware(tc.inputClient)
+			assert.NotNil(t, middleware)
+
+			// The middleware should work without panicking
+			// We can't fully test without mocking mcp.MethodHandler, but we verify creation
+		})
+	}
+}

--- a/pkg/invocation/http/http_invocation.go
+++ b/pkg/invocation/http/http_invocation.go
@@ -345,7 +345,8 @@ func (hi *HttpInvoker) executeHTTPRequest(
 		httpReq.Header.Set(contentTypeHeader, "application/json; charset=UTF-8")
 	}
 
-	client := &nethttp.Client{}
+	// Use HTTP client from context (configured with custom CA certs if provided)
+	client := HTTPClientFromContext(ctx)
 	response, err := client.Do(httpReq)
 	if err != nil {
 		baseLogger.Error("HTTP request execution failed", append(logFields, zap.Error(err))...)

--- a/pkg/invocation/http/middleware.go
+++ b/pkg/invocation/http/middleware.go
@@ -1,0 +1,25 @@
+package http
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// WithHTTPClientMiddleware creates an MCP middleware that injects a configured
+// HTTP client into the request context. This client is used by HTTP invokers
+// for outbound requests and can be configured with custom CA certificates.
+// If client is nil, http.DefaultClient will be used.
+func WithHTTPClientMiddleware(client *http.Client) mcp.Middleware {
+	// Ensure we never store nil - use DefaultClient as fallback
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return func(next mcp.MethodHandler) mcp.MethodHandler {
+		return func(ctx context.Context, method string, req mcp.Request) (result mcp.Result, err error) {
+			ctx = WithHTTPClient(ctx, client)
+			return next(ctx, method, req)
+		}
+	}
+}

--- a/specs/mcpserver-schema-0.2.0.json
+++ b/specs/mcpserver-schema-0.2.0.json
@@ -39,6 +39,24 @@
       ],
       "description": "CliInvocationConfig is the configuration for executing a command-line tool."
     },
+    "ClientTLSConfig": {
+      "properties": {
+        "caCertFiles": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "caCertDir": {
+          "type": "string"
+        },
+        "insecureSkipVerify": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "ExtendsConfig": {
       "properties": {
         "from": {
@@ -178,6 +196,9 @@
         },
         "loggingConfig": {
           "$ref": "#/$defs/LoggingConfig"
+        },
+        "clientTlsConfig": {
+          "$ref": "#/$defs/ClientTLSConfig"
         }
       },
       "additionalProperties": false,

--- a/specs/mcpserver-schema.json
+++ b/specs/mcpserver-schema.json
@@ -39,6 +39,24 @@
       ],
       "description": "CliInvocationConfig is the configuration for executing a command-line tool."
     },
+    "ClientTLSConfig": {
+      "properties": {
+        "caCertFiles": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "caCertDir": {
+          "type": "string"
+        },
+        "insecureSkipVerify": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "ExtendsConfig": {
       "properties": {
         "from": {
@@ -178,6 +196,9 @@
         },
         "loggingConfig": {
           "$ref": "#/$defs/LoggingConfig"
+        },
+        "clientTlsConfig": {
+          "$ref": "#/$defs/ClientTLSConfig"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
This adds clientTlsConfig to ServerRuntime for configuring TLS settings on outbound HTTP requests made by the MCP server (e.g., when tools invoke external APIs).

Features:
- caCertFiles: specify individual CA certificate files (PEM format)
- caCertDir: specify a directory containing CA certificates
- insecureSkipVerify: skip TLS verification (testing only)

The CA certificates are added to the system's default certificate pool, so standard public CAs remain trusted.

Environment variable overrides are automatically supported:
- GENMCP_CLIENTTLSCONFIG_CACERTFILES
- GENMCP_CLIENTTLSCONFIG_CACERTDIR
- GENMCP_CLIENTTLSCONFIG_INSECURESKIPVERIFY

Fixes #284

## What type of PR is this?

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind cleanup
/kind documentation
/kind testing
-->

## What this PR does / why we need it:

## Which issue(s) this PR fixes:

Fixes #

## Proposed Changes
-
-
-

## Release note:
<!--  Write your release note if needed:
Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for custom CA certificates for outbound HTTPS requests via a new clientTlsConfig option, allowing connections to services using corporate/private CAs and optional skip-verify.

* **Documentation**
  * Expanded docs with examples, environment-variable overrides, and Kubernetes guidance for outbound TLS trust stores and combined TLS/OAuth scenarios.

* **Tests**
  * Added unit tests covering TLS client configuration, CA loading, and HTTP client behavior/caching.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->