### PR TITLE
feat(streamablehttp): add support for k8s probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Support for liveness/readiness probes in the streamable HTTP server (#291).
+
 ## [v0.2.3]
 
 ### Added

--- a/pkg/config/server/parser.go
+++ b/pkg/config/server/parser.go
@@ -112,6 +112,14 @@ func (s *MCPServerConfig) UnmarshalJSON(data []byte) error {
 		}
 	}
 
+	if s.Runtime.TransportProtocol == TransportProtocolStreamableHttp && s.Runtime.StreamableHTTPConfig.Health == nil {
+		s.Runtime.StreamableHTTPConfig.Health = &HealthConfig{
+			Enabled:       true,
+			ReadinessPath: "/readyz",
+			LivenessPath:  "/healthz",
+		}
+	}
+
 	return nil
 
 }

--- a/pkg/config/server/parser_test.go
+++ b/pkg/config/server/parser_test.go
@@ -27,6 +27,11 @@ func TestParseMcpFile(t *testing.T) {
 							Port:      3000,
 							BasePath:  DefaultBasePath,
 							Stateless: true,
+							Health: &HealthConfig{
+								Enabled:       true,
+								ReadinessPath: "/readyz",
+								LivenessPath:  "/healthz",
+							},
 						},
 					},
 				},
@@ -44,6 +49,11 @@ func TestParseMcpFile(t *testing.T) {
 							BasePath:  DefaultBasePath,
 							Port:      3000,
 							Stateless: false,
+							Health: &HealthConfig{
+								Enabled:       true,
+								ReadinessPath: "/readyz",
+								LivenessPath:  "/healthz",
+							},
 						},
 					},
 				},
@@ -72,6 +82,11 @@ func TestParseMcpFile(t *testing.T) {
 						StreamableHTTPConfig: &StreamableHTTPConfig{
 							Port:      8008,
 							Stateless: true,
+							Health: &HealthConfig{
+								Enabled:       true,
+								ReadinessPath: "/readyz",
+								LivenessPath:  "/healthz",
+							},
 						},
 					},
 				},
@@ -91,6 +106,11 @@ func TestParseMcpFile(t *testing.T) {
 							TLS: &TLSConfig{
 								CertFile: "/path/to/server.crt",
 								KeyFile:  "/path/to/server.key",
+							},
+							Health: &HealthConfig{
+								Enabled:       true,
+								ReadinessPath: "/readyz",
+								LivenessPath:  "/healthz",
 							},
 						},
 					},

--- a/pkg/config/server/types.go
+++ b/pkg/config/server/types.go
@@ -32,6 +32,9 @@ type StreamableHTTPConfig struct {
 
 	// TLS configuration for HTTPS.
 	TLS *TLSConfig `json:"tls,omitempty" jsonschema:"optional"`
+
+	// Health check configuration for k8s probes.
+	Health *HealthConfig `json:"health,omitempty" jsonschema:"optional"`
 }
 
 // TLSConfig defines paths to TLS certificate and private key files.
@@ -41,6 +44,17 @@ type TLSConfig struct {
 
 	// Absolute path to the server's private key.
 	KeyFile string `json:"keyFile,omitempty" jsonschema:"optional"`
+}
+
+type HealthConfig struct {
+	// Enable health endpoints (default: true when running HTTP)
+	Enabled bool `json:"enabled,omitempty" jsonschema:"optional"`
+
+	// Path for liveness probe (default: /healthz)
+	LivenessPath string `json:"livenessPath,omitempty" jsonschema:"optional"`
+
+	// Path for readiness probe (default: /readyz)
+	ReadinessPath string `json:"readinessPath,omitempty" jsonschema:"optional"`
 }
 
 // ClientTLSConfig defines TLS settings for outbound HTTP requests.

--- a/pkg/health/handlers.go
+++ b/pkg/health/handlers.go
@@ -1,0 +1,42 @@
+package health
+
+import (
+	"net/http"
+	"sync/atomic"
+)
+
+type Checker interface {
+	SetReady(ready bool)
+	LivenessHandler(w http.ResponseWriter, r *http.Request)
+	ReadinessHandler(w http.ResponseWriter, r *http.Request)
+}
+
+type checker struct {
+	ready atomic.Bool
+}
+
+var _ Checker = &checker{}
+
+func NewChecker() Checker {
+	return &checker{}
+}
+
+func (c *checker) SetReady(ready bool) {
+	c.ready.Store(ready)
+}
+
+func (c *checker) LivenessHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
+}
+
+func (c *checker) ReadinessHandler(w http.ResponseWriter, r *http.Request) {
+	if c.ready.Load() {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+		return
+	}
+
+	w.WriteHeader(http.StatusServiceUnavailable)
+	_, _ = w.Write([]byte("not ready"))
+}

--- a/pkg/health/handlers_test.go
+++ b/pkg/health/handlers_test.go
@@ -1,0 +1,110 @@
+package health
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewChecker(t *testing.T) {
+	c := NewChecker()
+	assert.NotNil(t, c)
+}
+
+func TestLivenessHandler_AlwaysReturns200(t *testing.T) {
+	c := NewChecker()
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+
+	c.LivenessHandler(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "ok", rec.Body.String())
+}
+
+func TestReadinessHandler_Returns503WhenNotReady(t *testing.T) {
+	c := NewChecker()
+	// Default state is not ready
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rec := httptest.NewRecorder()
+
+	c.ReadinessHandler(rec, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.Equal(t, "not ready", rec.Body.String())
+}
+
+func TestReadinessHandler_Returns200WhenReady(t *testing.T) {
+	c := NewChecker()
+	c.SetReady(true)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rec := httptest.NewRecorder()
+
+	c.ReadinessHandler(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "ok", rec.Body.String())
+}
+
+func TestSetReady_TogglesState(t *testing.T) {
+	c := NewChecker()
+
+	// Initially not ready
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rec := httptest.NewRecorder()
+	c.ReadinessHandler(rec, req)
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+
+	// Set ready
+	c.SetReady(true)
+	rec = httptest.NewRecorder()
+	c.ReadinessHandler(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Set not ready again
+	c.SetReady(false)
+	rec = httptest.NewRecorder()
+	c.ReadinessHandler(rec, req)
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+func TestReadinessHandler_ThreadSafety(t *testing.T) {
+	c := NewChecker()
+
+	var wg sync.WaitGroup
+	iterations := 1000
+
+	// Concurrent readers
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+				rec := httptest.NewRecorder()
+				c.ReadinessHandler(rec, req)
+				// Just ensure no panic - status can be either
+				assert.True(t, rec.Code == http.StatusOK || rec.Code == http.StatusServiceUnavailable)
+			}
+		}()
+	}
+
+	// Concurrent writers
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				c.SetReady(j%2 == 0)
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/specs/mcpserver-schema-0.2.0.json
+++ b/specs/mcpserver-schema-0.2.0.json
@@ -83,6 +83,21 @@
       ],
       "description": "ExtendsConfig allows extending an invocation base with modifications."
     },
+    "HealthConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "livenessPath": {
+          "type": "string"
+        },
+        "readinessPath": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "HttpInvocationConfig": {
       "properties": {
         "url": {
@@ -228,6 +243,9 @@
         },
         "tls": {
           "$ref": "#/$defs/TLSConfig"
+        },
+        "health": {
+          "$ref": "#/$defs/HealthConfig"
         }
       },
       "additionalProperties": false,

--- a/specs/mcpserver-schema.json
+++ b/specs/mcpserver-schema.json
@@ -83,6 +83,21 @@
       ],
       "description": "ExtendsConfig allows extending an invocation base with modifications."
     },
+    "HealthConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "livenessPath": {
+          "type": "string"
+        },
+        "readinessPath": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "HttpInvocationConfig": {
       "properties": {
         "url": {
@@ -228,6 +243,9 @@
         },
         "tls": {
           "$ref": "#/$defs/TLSConfig"
+        },
+        "health": {
+          "$ref": "#/$defs/HealthConfig"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
Fixes #290 

When deploying the MCP server with streamablehttp transport and on k8s/openshift, there is a problem since there is no readiness/liveness probe handlers on the server. This adds configurable options for both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Health check probes added for the streamable HTTP server: liveness and readiness endpoints
  * Default endpoints set to /healthz (liveness) and /readyz (readiness)
  * Conditional registration of health endpoints and runtime-controlled readiness flag
  * TLS/startup listener improvements for pre-binding and wrapping

* **Tests**
  * Comprehensive unit tests for health check behavior, readiness toggling, and concurrency

* **Schema**
  * Public schema extended to include health configuration (enabled, livenessPath, readinessPath)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->