### PR TITLE
fix(builder): add manifest annotations for registry label display

### DIFF
--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -210,8 +210,15 @@ func TestImageBuilder_Build(t *testing.T) {
 				configFile, err := img.ConfigFile()
 				assert.NoError(t, err)
 
+				// Verify config labels (for container runtime)
 				assert.Equal(t, "test-server", configFile.Config.Labels[McpServerNameLabel])
 				assert.Equal(t, "test-server", configFile.Config.Labels[ImageTitleLabel])
+
+				// Verify manifest annotations (for registry display like Quay.io)
+				manifest, err := img.Manifest()
+				assert.NoError(t, err)
+				assert.Equal(t, "test-server", manifest.Annotations[McpServerNameLabel])
+				assert.Equal(t, "test-server", manifest.Annotations[ImageTitleLabel])
 			},
 		},
 		{


### PR DESCRIPTION

/kind bug


## Which issue(s) this PR fixes:

Fixes #283 

## Proposed Changes
- Config labels are only visible at container runtime. Registries like Quay.io display manifest annotations instead. Add mutate.Annotations() call to set OCI labels on both the config and the manifest.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Images now include registry-level annotations with metadata such as title, description, creation time, server name, version, and reference information for improved organization at the registry level.

* **Tests**
  * Enhanced test coverage for image annotation and configuration validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->