### PR TITLE
Fix OpenAPI converter to fall back to summary when description is absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- OpenAPI converter now falls back to `summary` when `description` is absent (#320)
+
 ### Added
 - New `genmcp inspect` command to view detailed MCP server configuration. Displays server metadata, tools, prompts, resources, and resource templates with descriptions. Shows security status (TLS/Auth) for StreamableHTTP transport without exposing sensitive values (StdioConfig has no security configuration). Generates MCP client configuration JSON for easy client setup. Supports `--json` flag for machine-readable output and name-based lookup of running detached servers. (#299, fixes #280)
 - Support for liveness/readiness probes in the streamable HTTP server (#291).

--- a/pkg/converter/openapi/openapi.go
+++ b/pkg/converter/openapi/openapi.go
@@ -160,10 +160,15 @@ func McpFilesFromOpenApiV2Model(model *v2high.Swagger, host string) (*ConvertedM
 				continue
 			}
 
+			description := operation.Description
+			if description == "" {
+				description = operation.Summary
+			}
+
 			tool := &definitions.Tool{
 				Name:        toolName(pathName, operationMethod),
 				Title:       operation.Summary,
-				Description: operation.Description,
+				Description: description,
 				InputSchema: &jsonschema.Schema{
 					Type:       invocation.JsonSchemaTypeObject,
 					Properties: make(map[string]*jsonschema.Schema),
@@ -358,10 +363,15 @@ func McpFilesFromOpenApiV3Model(model *v3high.Document, host string) (*Converted
 				continue
 			}
 
+			description := operation.Description
+			if description == "" {
+				description = operation.Summary
+			}
+
 			tool := &definitions.Tool{
 				Name:        toolName(pathName, operationMethod),
 				Title:       operation.Summary,
-				Description: operation.Description,
+				Description: description,
 				InputSchema: &jsonschema.Schema{
 					Type:       invocation.JsonSchemaTypeObject,
 					Properties: make(map[string]*jsonschema.Schema),

--- a/pkg/converter/openapi/openapi_test.go
+++ b/pkg/converter/openapi/openapi_test.go
@@ -8,6 +8,7 @@ import (
 	definitions "github.com/genmcp/gen-mcp/pkg/config/definitions"
 	serverconfig "github.com/genmcp/gen-mcp/pkg/config/server"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
 )
 
@@ -46,7 +47,7 @@ func TestInvalidToolsAreSkippedButValidOnesIncluded(t *testing.T) {
 	convertedFiles, err := DocumentToMcpFile(docBytes, "")
 
 	// One tool has neither summary nor description, so we expect an error about it being skipped
-	assert.Error(t, err, "conversion should report an error for the tool with no summary or description")
+	require.Error(t, err, "conversion should report an error for the tool with no summary or description")
 	assert.Contains(t, err.Error(), "get_truly-invalid-endpoint", "error should mention the skipped tool")
 	assert.NotNil(t, convertedFiles, "GenMCP config files should still be generated")
 	assert.NotNil(t, convertedFiles.ToolDefinitions, "tool definitions should be generated")
@@ -74,7 +75,7 @@ func TestAllToolsInvalidStillReturnsEmptyMcpFile(t *testing.T) {
 	convertedFiles, err := DocumentToMcpFile(docBytes, "")
 
 	// Should get an error about all invalid tools
-	assert.Error(t, err, "conversion should report errors about all invalid tools")
+	require.Error(t, err, "conversion should report errors about all invalid tools")
 	assert.NotNil(t, convertedFiles, "GenMCP config files should still be generated")
 	assert.NotNil(t, convertedFiles.ToolDefinitions, "tool definitions should be generated")
 
@@ -102,21 +103,41 @@ func TestSummaryFallbackWhenDescriptionAbsent(t *testing.T) {
 		toolsByName[tool.Name] = tool
 	}
 
-	// Summary-only operations should use summary as description
-	listUsers := toolsByName["get_users"]
-	assert.NotNil(t, listUsers, "should have get_users tool")
-	assert.Equal(t, "List all users", listUsers.Description, "summary-only tool should use summary as description")
-	assert.Equal(t, "List all users", listUsers.Title, "title should still be the summary")
+	tests := []struct {
+		name          string
+		toolKey       string
+		expectedDesc  string
+		expectedTitle string
+	}{
+		{
+			name:          "summary-only uses summary as description",
+			toolKey:       "get_users",
+			expectedDesc:  "List all users",
+			expectedTitle: "List all users",
+		},
+		{
+			name:         "summary-only without title check",
+			toolKey:      "get_users-userId",
+			expectedDesc: "Get a user by ID",
+		},
+		{
+			name:          "both summary and description uses description",
+			toolKey:       "get_health",
+			expectedDesc:  "Returns the health status of the service",
+			expectedTitle: "Health check endpoint",
+		},
+	}
 
-	getUser := toolsByName["get_users-userId"]
-	assert.NotNil(t, getUser, "should have get_users-userId tool")
-	assert.Equal(t, "Get a user by ID", getUser.Description, "summary-only tool should use summary as description")
-
-	// Operation with both summary and description should use description
-	health := toolsByName["get_health"]
-	assert.NotNil(t, health, "should have get_health tool")
-	assert.Equal(t, "Returns the health status of the service", health.Description, "tool with both fields should use description")
-	assert.Equal(t, "Health check endpoint", health.Title, "title should be the summary")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tool := toolsByName[tc.toolKey]
+			require.NotNil(t, tool, "should have %s tool", tc.toolKey)
+			assert.Equal(t, tc.expectedDesc, tool.Description)
+			if tc.expectedTitle != "" {
+				assert.Equal(t, tc.expectedTitle, tool.Title)
+			}
+		})
+	}
 }
 
 func TestOpenAPIV2BodyParameterHandling(t *testing.T) {

--- a/pkg/converter/openapi/openapi_test.go
+++ b/pkg/converter/openapi/openapi_test.go
@@ -45,17 +45,18 @@ func TestInvalidToolsAreSkippedButValidOnesIncluded(t *testing.T) {
 
 	convertedFiles, err := DocumentToMcpFile(docBytes, "")
 
-	// With summary fallback, all tools should now be valid (summary fills in missing description)
-	assert.NoError(t, err, "conversion should not report errors when summary fallback is available")
+	// One tool has neither summary nor description, so we expect an error about it being skipped
+	assert.Error(t, err, "conversion should report an error for the tool with no summary or description")
+	assert.Contains(t, err.Error(), "get_truly-invalid-endpoint", "error should mention the skipped tool")
 	assert.NotNil(t, convertedFiles, "GenMCP config files should still be generated")
 	assert.NotNil(t, convertedFiles.ToolDefinitions, "tool definitions should be generated")
 
 	assert.NotNil(t, convertedFiles.ToolDefinitions.Tools, "tool definitions should have tools")
 
-	// All 3 tools should now be valid (the previously-invalid one gets summary as description)
+	// 3 valid tools: two with descriptions, one with summary fallback; the truly-invalid one is skipped
 	assert.Len(t, convertedFiles.ToolDefinitions.Tools, 3, "should have exactly 3 valid tools")
 
-	// Check that all tools are present
+	// Check that all valid tools are present
 	toolNames := make([]string, len(convertedFiles.ToolDefinitions.Tools))
 	for i, tool := range convertedFiles.ToolDefinitions.Tools {
 		toolNames[i] = tool.Name

--- a/pkg/converter/openapi/openapi_test.go
+++ b/pkg/converter/openapi/openapi_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	definitions "github.com/genmcp/gen-mcp/pkg/config/definitions"
 	serverconfig "github.com/genmcp/gen-mcp/pkg/config/server"
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/yaml"
@@ -44,17 +45,17 @@ func TestInvalidToolsAreSkippedButValidOnesIncluded(t *testing.T) {
 
 	convertedFiles, err := DocumentToMcpFile(docBytes, "")
 
-	// We should get an error about the invalid tool but still get valid GenMCP config files
-	assert.Error(t, err, "conversion should report errors about invalid tools")
+	// With summary fallback, all tools should now be valid (summary fills in missing description)
+	assert.NoError(t, err, "conversion should not report errors when summary fallback is available")
 	assert.NotNil(t, convertedFiles, "GenMCP config files should still be generated")
 	assert.NotNil(t, convertedFiles.ToolDefinitions, "tool definitions should be generated")
 
 	assert.NotNil(t, convertedFiles.ToolDefinitions.Tools, "tool definitions should have tools")
 
-	// Should have exactly 2 valid tools (the ones with descriptions)
-	assert.Len(t, convertedFiles.ToolDefinitions.Tools, 2, "should have exactly 2 valid tools")
+	// All 3 tools should now be valid (the previously-invalid one gets summary as description)
+	assert.Len(t, convertedFiles.ToolDefinitions.Tools, 3, "should have exactly 3 valid tools")
 
-	// Check that the valid tools are present
+	// Check that all tools are present
 	toolNames := make([]string, len(convertedFiles.ToolDefinitions.Tools))
 	for i, tool := range convertedFiles.ToolDefinitions.Tools {
 		toolNames[i] = tool.Name
@@ -62,11 +63,8 @@ func TestInvalidToolsAreSkippedButValidOnesIncluded(t *testing.T) {
 	}
 
 	assert.Contains(t, toolNames, "get_valid-endpoint", "should include the valid GET endpoint")
+	assert.Contains(t, toolNames, "get_invalid-endpoint", "should include the endpoint that fell back to summary")
 	assert.Contains(t, toolNames, "post_another-valid-endpoint", "should include the valid POST endpoint")
-
-	// Check that the error message contains information about the skipped tool
-	assert.Contains(t, err.Error(), "get_invalid-endpoint", "error should mention the skipped tool")
-	assert.Contains(t, err.Error(), "description is required", "error should mention why the tool was skipped")
 }
 
 func TestAllToolsInvalidStillReturnsEmptyMcpFile(t *testing.T) {
@@ -84,6 +82,40 @@ func TestAllToolsInvalidStillReturnsEmptyMcpFile(t *testing.T) {
 	// Check that error mentions both skipped tools
 	assert.Contains(t, err.Error(), "get_no-description-1", "error should mention first skipped tool")
 	assert.Contains(t, err.Error(), "post_no-description-2", "error should mention second skipped tool")
+}
+
+func TestSummaryFallbackWhenDescriptionAbsent(t *testing.T) {
+	docBytes, _ := os.ReadFile("testdata/openapi_v3_summary_only.json")
+
+	convertedFiles, err := DocumentToMcpFile(docBytes, "")
+	assert.NoError(t, err, "conversion should not produce errors")
+	assert.NotNil(t, convertedFiles, "GenMCP config files should be generated")
+	assert.NotNil(t, convertedFiles.ToolDefinitions, "tool definitions should be generated")
+
+	// All 3 tools should be generated (none skipped)
+	assert.Len(t, convertedFiles.ToolDefinitions.Tools, 3, "should have exactly 3 valid tools")
+
+	// Build a map of tool name -> tool for easier assertions
+	toolsByName := make(map[string]*definitions.Tool)
+	for _, tool := range convertedFiles.ToolDefinitions.Tools {
+		toolsByName[tool.Name] = tool
+	}
+
+	// Summary-only operations should use summary as description
+	listUsers := toolsByName["get_users"]
+	assert.NotNil(t, listUsers, "should have get_users tool")
+	assert.Equal(t, "List all users", listUsers.Description, "summary-only tool should use summary as description")
+	assert.Equal(t, "List all users", listUsers.Title, "title should still be the summary")
+
+	getUser := toolsByName["get_users-userId"]
+	assert.NotNil(t, getUser, "should have get_users-userId tool")
+	assert.Equal(t, "Get a user by ID", getUser.Description, "summary-only tool should use summary as description")
+
+	// Operation with both summary and description should use description
+	health := toolsByName["get_health"]
+	assert.NotNil(t, health, "should have get_health tool")
+	assert.Equal(t, "Returns the health status of the service", health.Description, "tool with both fields should use description")
+	assert.Equal(t, "Health check endpoint", health.Title, "title should be the summary")
 }
 
 func TestOpenAPIV2BodyParameterHandling(t *testing.T) {

--- a/pkg/converter/openapi/testdata/openapi_v3_all_invalid_tools.json
+++ b/pkg/converter/openapi/testdata/openapi_v3_all_invalid_tools.json
@@ -12,7 +12,6 @@
   "paths": {
     "/no-description-1": {
       "get": {
-        "summary": "No description endpoint 1",
         "operationId": "getNoDescription1",
         "responses": {
           "200": {
@@ -23,7 +22,6 @@
     },
     "/no-description-2": {
       "post": {
-        "summary": "No description endpoint 2",
         "operationId": "postNoDescription2",
         "responses": {
           "200": {

--- a/pkg/converter/openapi/testdata/openapi_v3_summary_only.json
+++ b/pkg/converter/openapi/testdata/openapi_v3_summary_only.json
@@ -1,0 +1,58 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test API with Summary-Only Operations",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.example.com"
+    }
+  ],
+  "paths": {
+    "/users": {
+      "get": {
+        "summary": "List all users",
+        "operationId": "listUsers",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/users/{userId}": {
+      "get": {
+        "summary": "Get a user by ID",
+        "operationId": "getUser",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "summary": "Health check endpoint",
+        "description": "Returns the health status of the service",
+        "operationId": "healthCheck",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    }
+  }
+}

--- a/pkg/converter/openapi/testdata/openapi_v3_with_invalid_tools.json
+++ b/pkg/converter/openapi/testdata/openapi_v3_with_invalid_tools.json
@@ -33,6 +33,16 @@
         }
       }
     },
+    "/truly-invalid-endpoint": {
+      "get": {
+        "operationId": "getTrulyInvalidEndpoint",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
     "/another-valid-endpoint": {
       "post": {
         "summary": "Another valid endpoint",


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it:

When OpenAPI operations define `summary` but not `description`, the converter skips them with `invalid tool: description is required`. Many real-world API specs (e.g., CDC PRIME Data Input API) use only `summary` at the operation level, and the OpenAPI specification makes both fields optional. This can result in 0 tools generated from a valid spec.

This PR adds a fallback: if `description` is empty, use `summary` as the tool description. The fix applies to both V2 and V3 converter paths.

## Which issue(s) this PR fixes:
Fixes #320

## Proposed Changes
- Add description fallback logic in both `McpFilesFromOpenApiV2Model` and `McpFilesFromOpenApiV3Model`
- Add test fixture (`openapi_v3_summary_only.json`) with summary-only operations
- Add `TestSummaryFallbackWhenDescriptionAbsent` test covering: summary-only, both-fields, and neither-field cases
- Update existing test expectations to reflect that summary-only operations are now valid
- Add changelog entry

```release-note
OpenAPI converter now falls back to `summary` when `description` is absent, preventing valid specs from producing empty output.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Converter now falls back to operation summaries when descriptions are missing, improving conversion reliability and reducing skipped tools.

* **Tests**
  * Added and updated tests to verify summary-as-description fallback and ensure invalid operations remain skipped while valid ones are included.

* **Test Data**
  * New and updated OpenAPI fixtures covering summary-only and truly-invalid operation cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genmcp/gen-mcp/pull/321?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->